### PR TITLE
Switch to MySQLi and drop DOB field

### DIFF
--- a/api/_login_user.php
+++ b/api/_login_user.php
@@ -16,9 +16,11 @@ if ($errors) {
     exit;
 }
 
-$stmt = $pdo->prepare('SELECT * FROM users WHERE email = ? LIMIT 1');
-$stmt->execute([$email]);
-$user = $stmt->fetch();
+$stmt = $mysqli->prepare('SELECT * FROM users WHERE email = ? LIMIT 1');
+$stmt->bind_param('s', $email);
+$stmt->execute();
+$result = $stmt->get_result();
+$user = $result->fetch_assoc();
 if ($user && password_verify($password, $user['password'])) {
     $_SESSION['user_id'] = $user['id'];
     $_SESSION['user_name'] = $user['first_name'];

--- a/db.php
+++ b/db.php
@@ -1,25 +1,20 @@
 <?php
+// Database connection using MySQLi
 $host = '127.0.0.1';
 $db   = 'onepdf';
 $user = 'root';
 $pass = '';
 $charset = 'utf8mb4';
 
-$dsn = "mysql:host=$host;dbname=$db;charset=$charset";
-$options = [
-    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-];
-
-try {
-    $pdo = new PDO($dsn, $user, $pass, $options);
-} catch (PDOException $e) {
+$mysqli = new mysqli($host, $user, $pass, $db);
+if ($mysqli->connect_error) {
     http_response_code(500);
     echo json_encode(['error' => 'Database connection failed']);
     exit;
 }
+$mysqli->set_charset($charset);
 
-$pdo->exec("CREATE TABLE IF NOT EXISTS users (
+$mysqli->query("CREATE TABLE IF NOT EXISTS users (
     id INT AUTO_INCREMENT PRIMARY KEY,
     use_id CHAR(16) NOT NULL,
     country VARCHAR(100) NOT NULL,
@@ -28,7 +23,6 @@ $pdo->exec("CREATE TABLE IF NOT EXISTS users (
     company VARCHAR(100) NOT NULL,
     email VARCHAR(150) NOT NULL UNIQUE,
     password VARCHAR(255) NOT NULL,
-    dob DATE NOT NULL,
     agreed_terms TINYINT(1) NOT NULL DEFAULT 0
 )");
 ?>

--- a/registration.php
+++ b/registration.php
@@ -123,11 +123,6 @@
                 </div>
                 <div id="company_error" class="error-message"></div>
 
-                <div class="form-floating mb-3">
-                    <input type="text" name="dob" class="form-control" id="dob" placeholder="dd-mm-yyyy" required pattern="\d{2}-\d{2}-\d{4}">
-                    <label for="dob">Date of Birth (dd-mm-yyyy)</label>
-                </div>
-                <div id="dob_error" class="error-message"></div>
 
                 <div class="form-floating mb-3">
                     <input type="email" name="email" class="form-control" id="email" placeholder="name@example.com" required>
@@ -201,12 +196,6 @@ document.getElementById('registerForm').addEventListener('submit', async functio
     if (!data.get('company')) {
         document.getElementById('company_error').textContent = 'Company is required.';
         document.getElementById('company').classList.add('is-invalid');
-        valid = false;
-    }
-    const dob = data.get('dob');
-    if (!dob || !/^\d{2}-\d{2}-\d{4}$/.test(dob)) {
-        document.getElementById('dob_error').textContent = 'Date of birth must be in dd-mm-yyyy format.';
-        document.getElementById('dob').classList.add('is-invalid');
         valid = false;
     }
     const email = data.get('email');


### PR DESCRIPTION
## Summary
- Replace PDO usage with MySQLi connection and remove DOB column
- Generate 16-digit IDs safely and save users with MySQLi
- Update login logic to MySQLi
- Simplify registration form by removing DOB input and validation

## Testing
- `php -l db.php`
- `php -l api/_save_user.php`
- `php -l api/_login_user.php`
- `php -l registration.php`
- ⚠️ `php -r '$_POST=["country"=>"USA","first_name"=>"John","last_name"=>"Doe","company"=>"ACME","email"=>"john@example.com","password"=>"secret123","agreed_terms"=>"1"]; include "api/_save_user.php";'` (fails: Connection refused)


------
https://chatgpt.com/codex/tasks/task_e_68b01b9749bc8327b0209e1a6f4e035d