### PR TITLE
Add vendor logout and profile update page

### DIFF
--- a/api/_update_user.php
+++ b/api/_update_user.php
@@ -1,0 +1,39 @@
+<?php
+require_once __DIR__ . '/../config.php';
+header('Content-Type: application/json');
+
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    echo json_encode(['error' => 'Unauthorized']);
+    exit;
+}
+
+$user_id = $_SESSION['user_id'];
+$first_name = trim($_POST['first_name'] ?? '');
+$last_name  = trim($_POST['last_name'] ?? '');
+$company    = trim($_POST['company'] ?? '');
+$country    = trim($_POST['country'] ?? '');
+$email      = trim($_POST['email'] ?? '');
+
+$errors = [];
+if ($first_name === '') $errors[] = 'First name is required';
+if ($last_name === '')  $errors[] = 'Last name is required';
+if ($company === '')    $errors[] = 'Company is required';
+if ($country === '')    $errors[] = 'Country is required';
+if ($email === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) $errors[] = 'Valid email is required';
+
+if ($errors) {
+    echo json_encode(['error' => implode(', ', $errors)]);
+    exit;
+}
+
+$stmt = $mysqli->prepare('UPDATE users SET first_name = ?, last_name = ?, company = ?, country = ?, email = ? WHERE id = ?');
+$stmt->bind_param('sssssi', $first_name, $last_name, $company, $country, $email, $user_id);
+
+if ($stmt->execute()) {
+    $_SESSION['user_name'] = $first_name;
+    echo json_encode(['success' => true]);
+} else {
+    echo json_encode(['error' => 'Failed to update user']);
+}
+?>

--- a/login.php
+++ b/login.php
@@ -143,7 +143,7 @@
      
       if (result.success) {
         toastr.success('Login successful. Redirecting to dashboard...', 'Success');
-        setTimeout(() => window.location = 'dashboard.php', 1500);
+        setTimeout(() => window.location = 'vendor_dashboard/dashboard.php', 1500);
       } else {
         toastr.error(result.error || 'Login failed.', 'Error');
       }

--- a/vendor_dashboard/dashboard.php
+++ b/vendor_dashboard/dashboard.php
@@ -1,4 +1,9 @@
-<?php 
+<?php
+require_once '../config.php';
+if (!isset($_SESSION['user_id'])) {
+    header('Location: ../login.php');
+    exit;
+}
 // Define the base path for includes
 define('INCLUDE_PATH', __DIR__ . '/includes/');
 

--- a/vendor_dashboard/includes/footer.php
+++ b/vendor_dashboard/includes/footer.php
@@ -33,7 +33,7 @@
             <div class="modal-body">Select "Logout" below if you are ready to end your current session.</div>
             <div class="modal-footer">
                 <button class="btn btn-secondary" type="button" data-dismiss="modal">Cancel</button>
-                <a class="btn btn-primary" href="login.html">Logout</a>
+                <a class="btn btn-primary" href="../logout.php">Logout</a>
             </div>
         </div>
     </div>

--- a/vendor_dashboard/includes/topbar.php
+++ b/vendor_dashboard/includes/topbar.php
@@ -137,14 +137,14 @@
             <li class="nav-item dropdown no-arrow">
                 <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button"
                     data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                    <span class="mr-2 d-none d-lg-inline text-gray-600 small">Douglas McGee</span>
+                    <span class="mr-2 d-none d-lg-inline text-gray-600 small"><?php echo htmlspecialchars($_SESSION['user_name'] ?? 'User'); ?></span>
                     <img class="img-profile rounded-circle"
                         src="<?php echo $assets_path; ?>img/undraw_profile.svg">
                 </a>
                 <!-- Dropdown - User Information -->
                 <div class="dropdown-menu dropdown-menu-right shadow animated--grow-in"
                     aria-labelledby="userDropdown">
-                    <a class="dropdown-item" href="#">
+                    <a class="dropdown-item" href="profile.php">
                         <i class="bi bi-person-fill me-2 text-gray-400"></i>
                         Profile
                     </a>

--- a/vendor_dashboard/profile.php
+++ b/vendor_dashboard/profile.php
@@ -1,0 +1,64 @@
+<?php
+require_once '../config.php';
+if (!isset($_SESSION['user_id'])) {
+    header('Location: ../login.php');
+    exit;
+}
+$user_id = $_SESSION['user_id'];
+$stmt = $mysqli->prepare('SELECT first_name, last_name, company, country, email FROM users WHERE id = ?');
+$stmt->bind_param('i', $user_id);
+$stmt->execute();
+$user = $stmt->get_result()->fetch_assoc();
+
+define('INCLUDE_PATH', __DIR__ . '/includes/');
+
+include(INCLUDE_PATH . 'header.php');
+include(INCLUDE_PATH . 'sidebar.php');
+include(INCLUDE_PATH . 'topbar.php');
+?>
+        <!-- Begin Page Content -->
+        <div class="container-fluid">
+            <h1 class="h3 mb-4 text-gray-800">Profile</h1>
+            <form id="profileForm" class="col-lg-6">
+                <div class="mb-3">
+                    <label class="form-label">First Name</label>
+                    <input type="text" name="first_name" class="form-control" value="<?php echo htmlspecialchars($user['first_name'] ?? ''); ?>" required>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Last Name</label>
+                    <input type="text" name="last_name" class="form-control" value="<?php echo htmlspecialchars($user['last_name'] ?? ''); ?>" required>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Company</label>
+                    <input type="text" name="company" class="form-control" value="<?php echo htmlspecialchars($user['company'] ?? ''); ?>" required>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Country</label>
+                    <input type="text" name="country" class="form-control" value="<?php echo htmlspecialchars($user['country'] ?? ''); ?>" required>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Email</label>
+                    <input type="email" name="email" class="form-control" value="<?php echo htmlspecialchars($user['email'] ?? ''); ?>" required>
+                </div>
+                <button type="submit" class="btn btn-primary">Save</button>
+            </form>
+        </div>
+        <!-- /.container-fluid -->
+    </div>
+    <!-- End of Main Content -->
+    <script>
+    document.getElementById('profileForm').addEventListener('submit', async function(e){
+        e.preventDefault();
+        const formData = new FormData(this);
+        const res = await fetch('../api/_update_user.php', {method:'POST', body: formData});
+        const result = await res.json();
+        if(result.success){
+            alert('Profile updated successfully');
+        } else {
+            alert(result.error || 'Update failed');
+        }
+    });
+    </script>
+<?php
+include(INCLUDE_PATH . 'footer.php');
+?>


### PR DESCRIPTION
## Summary
- Redirect login to vendor dashboard
- Add logout link and profile navigation to vendor dashboard
- Implement profile page and API for updating vendor details

## Testing
- `php -l login.php`
- `php -l vendor_dashboard/dashboard.php`
- `php -l vendor_dashboard/profile.php`
- `php -l vendor_dashboard/includes/topbar.php`
- `php -l vendor_dashboard/includes/footer.php`
- `php -l api/_update_user.php`


------
https://chatgpt.com/codex/tasks/task_e_68b01e237984832786a845e64adaf3be