### PR TITLE
Fix profile update path and add password change API

### DIFF
--- a/vendor_dashboard/api/_change_password.php
+++ b/vendor_dashboard/api/_change_password.php
@@ -1,0 +1,51 @@
+<?php
+require_once __DIR__ . '/../../config.php';
+header('Content-Type: application/json');
+
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    echo json_encode(['error' => 'Unauthorized']);
+    exit;
+}
+
+$user_id = $_SESSION['user_id'];
+$current    = $_POST['current_password'] ?? '';
+$new        = $_POST['new_password'] ?? '';
+$confirm    = $_POST['confirm_password'] ?? '';
+
+$errors = [];
+if ($current === '') {
+    $errors[] = 'Current password is required';
+}
+if ($new === '' || strlen($new) < 6) {
+    $errors[] = 'New password must be at least 6 characters';
+}
+if ($new !== $confirm) {
+    $errors[] = 'Passwords do not match';
+}
+
+if ($errors) {
+    echo json_encode(['error' => implode(', ', $errors)]);
+    exit;
+}
+
+$stmt = $mysqli->prepare('SELECT password FROM users WHERE id = ?');
+$stmt->bind_param('i', $user_id);
+$stmt->execute();
+$result = $stmt->get_result();
+$user = $result->fetch_assoc();
+if (!$user || !password_verify($current, $user['password'])) {
+    echo json_encode(['error' => 'Current password is incorrect']);
+    exit;
+}
+
+$new_hash = password_hash($new, PASSWORD_DEFAULT);
+$update = $mysqli->prepare('UPDATE users SET password = ? WHERE id = ?');
+$update->bind_param('si', $new_hash, $user_id);
+
+if ($update->execute()) {
+    echo json_encode(['success' => true]);
+} else {
+    echo json_encode(['error' => 'Failed to update password']);
+}
+?>

--- a/vendor_dashboard/change_password.php
+++ b/vendor_dashboard/change_password.php
@@ -1,11 +1,81 @@
 <?php
-require_once __DIR__ . '/../config.php';
-include 'includes/header.php';
-include 'includes/sidebar.php';
-include 'includes/topbar.php';
+require_once '../config.php';
+if (!isset($_SESSION['user_id'])) {
+    header('Location: ../login.php');
+    exit;
+}
+
+define('INCLUDE_PATH', __DIR__ . '/includes/');
+include(INCLUDE_PATH . 'header.php');
+include(INCLUDE_PATH . 'sidebar.php');
+include(INCLUDE_PATH . 'topbar.php');
 ?>
 <div class="container-fluid">
-    <h1 class="h3 mb-4 text-gray-800">Change Password</h1>
-    <p>This is a placeholder change password page.</p>
+  <h1 class="h3 mb-4 text-gray-800"><i class="bi bi-key mr-2"></i> Change Password</h1>
+  <div class="row">
+    <div class="col-lg-6">
+      <div class="card shadow-sm mb-4">
+        <div class="card-header d-flex align-items-center">
+          <i class="bi bi-shield-lock mr-2"></i>
+          <span class="font-weight-bold">Update Password</span>
+        </div>
+        <div class="card-body">
+          <form id="passwordForm" novalidate>
+            <div class="form-group">
+              <label for="currentPassword" class="form-label"><i class="bi bi-lock mr-1"></i> Current Password</label>
+              <input type="password" name="current_password" id="currentPassword" class="form-control" required>
+            </div>
+            <div class="form-group">
+              <label for="newPassword" class="form-label"><i class="bi bi-shield-lock mr-1"></i> New Password</label>
+              <input type="password" name="new_password" id="newPassword" class="form-control" required minlength="6">
+            </div>
+            <div class="form-group">
+              <label for="confirmPassword" class="form-label"><i class="bi bi-shield-check mr-1"></i> Confirm Password</label>
+              <input type="password" name="confirm_password" id="confirmPassword" class="form-control" required minlength="6">
+            </div>
+            <button type="submit" id="btnChange" class="btn btn-primary">
+              <i class="bi bi-save mr-1"></i> Save
+            </button>
+            <button type="reset" class="btn btn-outline-secondary ml-2">
+              <i class="bi bi-arrow-counterclockwise mr-1"></i> Reset
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
-<?php include 'includes/footer.php'; ?>
+<script>
+(function(){
+  const form = document.getElementById('passwordForm');
+  const btn  = document.getElementById('btnChange');
+
+  form.addEventListener('submit', async function(e){
+    e.preventDefault();
+    if (!form.checkValidity()) {
+      alert('Please fill all required fields.');
+      return;
+    }
+    btn.disabled = true;
+    const original = btn.innerHTML;
+    btn.innerHTML = '<span class="spinner-border spinner-border-sm mr-2" role="status" aria-hidden="true"></span>Saving...';
+    try {
+      const formData = new FormData(form);
+      const res = await fetch('api/_change_password.php', { method:'POST', body: formData });
+      const result = await res.json();
+      if (result.success) {
+        alert('Password updated successfully');
+        form.reset();
+      } else {
+        alert(result.error || 'Update failed');
+      }
+    } catch(err) {
+      alert('Network error. Please try again.');
+    } finally {
+      btn.disabled = false;
+      btn.innerHTML = original;
+    }
+  });
+})();
+</script>
+<?php include(INCLUDE_PATH . 'footer.php'); ?>

--- a/vendor_dashboard/profile.php
+++ b/vendor_dashboard/profile.php
@@ -212,7 +212,7 @@ include(INCLUDE_PATH . 'topbar.php');   // top navbar
 
     try{
       const formData = new FormData(form);
-      const res = await fetch('../api/_update_user.php', { method:'POST', body: formData });
+      const res = await fetch('api/_update_user.php', { method:'POST', body: formData });
       const result = await res.json();
       if(result.success){
         alert('Profile updated successfully');


### PR DESCRIPTION
## Summary
- Correct profile update to call local API endpoint
- Add password change page with form and JavaScript logic
- Implement backend API to validate current password and update credentials

## Testing
- `php -l vendor_dashboard/profile.php`
- `php -l vendor_dashboard/change_password.php`
- `php -l vendor_dashboard/api/_change_password.php`


------
https://chatgpt.com/codex/tasks/task_e_68b03584bea483279f0a096371a04842