### PR TITLE
Fix change password API path

### DIFF
--- a/vendor_dashboard/change_password.php
+++ b/vendor_dashboard/change_password.php
@@ -164,7 +164,7 @@ document.querySelectorAll('.toggle-pass').forEach(function(icon){
 
     try{
       const formData = new FormData(form);
-      const res = await fetch('../api/_change_password.php', { method:'POST', body: formData });
+      const res = await fetch('api/_change_password.php', { method:'POST', body: formData });
       const result = await res.json();
       if(result.success){
         alert('Password updated successfully');


### PR DESCRIPTION
## Summary
- fix AJAX call in vendor dashboard to point to the correct API endpoint, resolving 404 errors when changing passwords

## Testing
- `php -l vendor_dashboard/change_password.php`
- `php -l vendor_dashboard/api/_change_password.php`


------
https://chatgpt.com/codex/tasks/task_e_68b03cc3816c832781352682c1553438