### PR TITLE
Fix vendor PDF uploads to root directory

### DIFF
--- a/uploads/.gitignore
+++ b/uploads/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/vendor_dashboard/api/delete_file.php
+++ b/vendor_dashboard/api/delete_file.php
@@ -19,7 +19,7 @@ if (!$stmt->fetch()) {
 }
 $stmt->close();
 
-$fullPath = __DIR__ . '/../uploads/' . $filepath;
+$fullPath = dirname(__DIR__, 2) . '/' . $filepath;
 if (file_exists($fullPath)) {
     unlink($fullPath);
 }

--- a/vendor_dashboard/api/upload_file.php
+++ b/vendor_dashboard/api/upload_file.php
@@ -16,7 +16,7 @@ if ($file['error'] !== UPLOAD_ERR_OK) {
 
 // Validate file type
 $finfo = finfo_open(FILEINFO_MIME_TYPE);
-$mime = finfo_file(finfo, $file['tmp_name']);
+$mime = finfo_file($finfo, $file['tmp_name']);
 finfo_close($finfo);
 if ($mime !== 'application/pdf') {
     http_response_code(400);
@@ -32,7 +32,7 @@ if ($file['size'] > $maxSize) {
     exit;
 }
 
-$uploadDir = __DIR__ . '/../uploads/';
+$uploadDir = dirname(__DIR__, 2) . '/uploads/';
 if (!is_dir($uploadDir)) {
     mkdir($uploadDir, 0777, true);
 }
@@ -52,7 +52,7 @@ if (!move_uploaded_file($file['tmp_name'], $target)) {
 }
 
 $stmt = $mysqli->prepare("INSERT INTO documents (filename, filepath, size) VALUES (?,?,?)");
-$relative = basename($target);
+$relative = 'uploads/' . basename($target);
 $stmt->bind_param('ssi', $filename, $relative, $file['size']);
 $stmt->execute();
 

--- a/vendor_dashboard/upload.php
+++ b/vendor_dashboard/upload.php
@@ -46,8 +46,7 @@ $('#uploadForm').on('submit', function(e){
         contentType: false,
         processData: false,
         success: function(){
-            $('#alert').html('<div class="alert alert-success">Uploaded</div>');
-            loadFiles();
+            window.location.reload();
         },
         error: function(xhr){
             var msg = xhr.responseJSON ? xhr.responseJSON.error : 'Upload failed';


### PR DESCRIPTION
## Summary
- Save uploaded PDFs in project-level `uploads` directory and record path for deletion
- Reload upload page after successful upload
- Add `.gitignore` to keep uploads folder empty in git

## Testing
- `php -l vendor_dashboard/api/upload_file.php vendor_dashboard/api/delete_file.php vendor_dashboard/upload.php`
- `curl -s -X POST -F pdf=@sample.pdf http://127.0.0.1:8000/vendor_dashboard/api/upload_file.php`
- `curl -s http://127.0.0.1:8000/vendor_dashboard/api/list_files.php | jq .`
- `curl -s -X POST -d "id=1" http://127.0.0.1:8000/vendor_dashboard/api/delete_file.php`
- `curl -s http://127.0.0.1:8000/vendor_dashboard/api/list_files.php | jq .`


------
https://chatgpt.com/codex/tasks/task_e_68b04466e46883278a354f63c6d42e91