### PR TITLE
Add custom link generator with permission modal and PDF viewer

### DIFF
--- a/file.php
+++ b/file.php
@@ -1,0 +1,71 @@
+<?php
+require_once __DIR__ . '/config.php';
+
+$slug = $_GET['code'] ?? '';
+if (!$slug) {
+    $uri = $_SERVER['REQUEST_URI'] ?? '';
+    if (preg_match('~/file/([a-zA-Z0-9]+)~', $uri, $m)) {
+        $slug = $m[1];
+    }
+}
+if (!$slug) {
+    echo 'Missing link code';
+    exit;
+}
+
+$stmt = $mysqli->prepare("SELECT l.id, l.permissions, d.filepath FROM links l JOIN documents d ON l.document_id=d.id WHERE l.slug=?");
+$stmt->bind_param('s', $slug);
+$stmt->execute();
+$stmt->bind_result($linkId, $permJson, $filepath);
+if (!$stmt->fetch()) {
+    echo 'Invalid link';
+    exit;
+}
+$stmt->close();
+
+$perms = json_decode($permJson, true) ?? [];
+if (!empty($perms['analytics'])) {
+    $ins = $mysqli->prepare("INSERT INTO link_analytics (link_id, event) VALUES (?, 'view')");
+    $ins->bind_param('i', $linkId);
+    $ins->execute();
+}
+$allowDownload = !empty($perms['download']);
+$allowSearch   = !empty($perms['search']);
+?>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>PDF Viewer</title>
+<style>
+  body,html{margin:0;height:100%;}
+  #viewer{border:none;width:100%;height:100%;}
+  .toolbar{display:flex;gap:10px;padding:8px;background:#f5f5f5;align-items:center;}
+  .toolbar input[type="text"]{flex:1;padding:4px 8px;}
+  .toolbar a{margin-left:auto;}
+</style>
+</head>
+<body>
+<div class="toolbar">
+<?php if($allowSearch){ ?>
+  <input type="text" id="searchBox" placeholder="Search...">
+<?php } ?>
+<?php if($allowDownload){ ?>
+  <a href="<?php echo htmlspecialchars($filepath); ?>" download>Download</a>
+<?php } ?>
+</div>
+<iframe id="viewer" src="<?php echo htmlspecialchars($filepath); ?>#toolbar=0"></iframe>
+<script>
+const searchBox=document.getElementById('searchBox');
+if(searchBox){
+  searchBox.addEventListener('keyup',function(e){
+    if(e.key==='Enter'){
+      const text=this.value;
+      const frame=document.getElementById('viewer');
+      frame.contentWindow.find && frame.contentWindow.find(text);
+    }
+  });
+}
+</script>
+</body>
+</html>

--- a/vendor_dashboard/api/generate_link.php
+++ b/vendor_dashboard/api/generate_link.php
@@ -1,0 +1,33 @@
+<?php
+require_once __DIR__ . '/../../config.php';
+
+$id = $_POST['id'] ?? null;
+$permJson = $_POST['permissions'] ?? null;
+if (!$id || !$permJson) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Missing parameters']);
+    exit;
+}
+
+$perms = json_decode($permJson, true);
+if ($perms === null) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid permissions']);
+    exit;
+}
+
+// Generate unique slug
+$slug = bin2hex(random_bytes(5));
+$url  = 'https://onepdf.io/file/' . $slug;
+
+$stmt = $mysqli->prepare("INSERT INTO links (document_id, slug, permissions) VALUES (?,?,?)");
+$stmt->bind_param('iss', $id, $slug, $permJson);
+$stmt->execute();
+
+if ($stmt->affected_rows <= 0) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Failed to save link']);
+    exit;
+}
+
+echo json_encode(['url' => $url]);

--- a/vendor_dashboard/db.php
+++ b/vendor_dashboard/db.php
@@ -34,4 +34,23 @@ $mysqli->query("CREATE TABLE IF NOT EXISTS documents (
     size BIGINT NOT NULL,
     uploaded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 )");
+
+// Table for generated links
+$mysqli->query("CREATE TABLE IF NOT EXISTS links (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    document_id INT NOT NULL,
+    slug VARCHAR(20) NOT NULL UNIQUE,
+    permissions JSON NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (document_id) REFERENCES documents(id) ON DELETE CASCADE
+)");
+
+// Analytics for link views
+$mysqli->query("CREATE TABLE IF NOT EXISTS link_analytics (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    link_id INT NOT NULL,
+    event VARCHAR(50) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (link_id) REFERENCES links(id) ON DELETE CASCADE
+)");
 ?>


### PR DESCRIPTION
## Summary
- add database tables for shareable links and basic analytics
- implement API endpoint to create unique links with JSON permissions
- enhance managed files page with permission modal and custom viewer

## Testing
- `php -l vendor_dashboard/api/generate_link.php file.php vendor_dashboard/db.php vendor_dashboard/file_list.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b077037e888327a2c806b4c6924731