### PR TITLE
Use dynamic base URL for generated links

### DIFF
--- a/vendor_dashboard/api/generate_link.php
+++ b/vendor_dashboard/api/generate_link.php
@@ -18,7 +18,11 @@ if ($perms === null) {
 
 // Generate unique slug
 $slug = bin2hex(random_bytes(5));
-$url  = 'https://onepdf.io/file/' . $slug;
+
+// Build base URL dynamically for localhost or production
+$scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https://' : 'http://';
+$host   = $_SERVER['HTTP_HOST'] ?? 'localhost';
+$url    = $scheme . $host . '/file/' . $slug;
 
 $stmt = $mysqli->prepare("INSERT INTO links (document_id, slug, permissions) VALUES (?,?,?)");
 $stmt->bind_param('iss', $id, $slug, $permJson);

--- a/vendor_dashboard/api/list_files.php
+++ b/vendor_dashboard/api/list_files.php
@@ -1,9 +1,15 @@
 <?php
 require_once __DIR__ . '/../../config.php';
 
-$result = $mysqli->query("SELECT id, filename, size, filepath FROM documents ORDER BY uploaded_at DESC");
+$result = $mysqli->query("SELECT d.id, d.filename, d.size, d.filepath, l.slug FROM documents d LEFT JOIN links l ON l.document_id = d.id ORDER BY d.uploaded_at DESC");
 $files = [];
+$scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https://' : 'http://';
+$host   = $_SERVER['HTTP_HOST'] ?? 'localhost';
 while ($row = $result->fetch_assoc()) {
+    if (!empty($row['slug'])) {
+        $row['url'] = $scheme . $host . '/file/' . $row['slug'];
+    }
+    unset($row['slug']);
     $files[] = $row;
 }
 

--- a/vendor_dashboard/file_list.php
+++ b/vendor_dashboard/file_list.php
@@ -218,14 +218,14 @@ include 'includes/topbar.php';
             <button class="btn btn-outline-primary btn-sm btn-icon generate" data-id="${f.id}">
               <i class="bi bi-link-45deg"></i> Generate
             </button>
-            <button class="btn btn-outline-secondary btn-sm btn-icon copy" ${url ? '' : 'disabled'} data-url="${url}">
+            <button class="btn btn-outline-secondary btn-sm btn-icon copy" data-url="${url}" ${url ? '' : 'disabled'}>
               <i class="bi bi-clipboard"></i> Copy
             </button>
             <button class="btn btn-outline-danger btn-sm delete" data-id="${f.id}">
               <i class="bi bi-trash"></i>
             </button>
           </div>
-          <div class="small text-muted mt-1 link-holder"></div>
+          <div class="small text-muted mt-1 link-holder">${url ? `<code>${url}</code>` : ''}</div>
         </td>
       `);
       $tbody.append($tr);


### PR DESCRIPTION
## Summary
- Generate share links with the current scheme and host instead of a hard-coded domain
- Include existing link URLs in the file list API and display them with copy buttons

## Testing
- `php -l vendor_dashboard/api/generate_link.php`
- `php -l vendor_dashboard/api/list_files.php`
- `php -l vendor_dashboard/file_list.php`

------
https://chatgpt.com/codex/tasks/task_e_68b08939c34c83279e53fa7ffe228d62