### PR TITLE
fix: respect project base path when generating links

### DIFF
--- a/vendor_dashboard/api/generate_link.php
+++ b/vendor_dashboard/api/generate_link.php
@@ -22,7 +22,10 @@ $slug = bin2hex(random_bytes(5));
 // Build base URL dynamically for localhost or production
 $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https://' : 'http://';
 $host   = $_SERVER['HTTP_HOST'] ?? 'localhost';
-$url    = $scheme . $host . '/file/' . $slug;
+// Determine the application's base path (e.g. "/onepdf-view") so generated
+// links work whether the project lives in a subdirectory or at the web root.
+$basePath = rtrim(dirname(dirname(dirname($_SERVER['SCRIPT_NAME'] ?? ''))), '/');
+$url      = $scheme . $host . $basePath . '/file/' . $slug;
 
 $stmt = $mysqli->prepare("INSERT INTO links (document_id, slug, permissions) VALUES (?,?,?)");
 $stmt->bind_param('iss', $id, $slug, $permJson);


### PR DESCRIPTION
## Summary
- compute project base path when generating share links so URLs work from subdirectory deployments

## Testing
- `php -l vendor_dashboard/api/generate_link.php`


------
https://chatgpt.com/codex/tasks/task_e_68b08c1e00ec83279c78965e50f9c9df