### PR TITLE
fix: ensure generated PDF links open correctly

### DIFF
--- a/vendor_dashboard/api/generate_link.php
+++ b/vendor_dashboard/api/generate_link.php
@@ -2,8 +2,10 @@
 require_once __DIR__ . '/../../config.php';
 
 $id = $_POST['id'] ?? null;
-$permJson = $_POST['permissions'] ?? null;
-if (!$id || !$permJson) {
+// Allow optional permissions.  If none are provided default to an empty JSON
+// object so links can still be generated and later viewed.
+$permJson = $_POST['permissions'] ?? '{}';
+if (!$id) {
     http_response_code(400);
     echo json_encode(['error' => 'Missing parameters']);
     exit;
@@ -11,9 +13,8 @@ if (!$id || !$permJson) {
 
 $perms = json_decode($permJson, true);
 if ($perms === null) {
-    http_response_code(400);
-    echo json_encode(['error' => 'Invalid permissions']);
-    exit;
+    // Malformed JSON – fall back to no permissions instead of failing.
+    $permJson = '{}';
 }
 
 // Generate unique slug

--- a/vendor_dashboard/api/list_files.php
+++ b/vendor_dashboard/api/list_files.php
@@ -3,11 +3,14 @@ require_once __DIR__ . '/../../config.php';
 
 $result = $mysqli->query("SELECT d.id, d.filename, d.size, d.filepath, l.slug FROM documents d LEFT JOIN links l ON l.document_id = d.id ORDER BY d.uploaded_at DESC");
 $files = [];
-$scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https://' : 'http://';
-$host   = $_SERVER['HTTP_HOST'] ?? 'localhost';
+$scheme   = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https://' : 'http://';
+$host     = $_SERVER['HTTP_HOST'] ?? 'localhost';
+// Ensure links work whether the project lives at the web root or in a
+// subdirectory by prepending the detected base path.
+$basePath = rtrim(dirname(dirname(dirname($_SERVER['SCRIPT_NAME'] ?? ''))), '/');
 while ($row = $result->fetch_assoc()) {
     if (!empty($row['slug'])) {
-        $row['url'] = $scheme . $host . '/file/' . $row['slug'];
+        $row['url'] = $scheme . $host . $basePath . '/file/' . $row['slug'];
     }
     unset($row['slug']);
     $files[] = $row;


### PR DESCRIPTION
## Summary
- Allow link generation without explicit permissions and handle malformed data
- Include application base path when listing file URLs so links open correctly

## Testing
- `php -l vendor_dashboard/api/generate_link.php vendor_dashboard/api/list_files.php`


------
https://chatgpt.com/codex/tasks/task_e_68b08e02175883278255ee5a96e89aac