### PR TITLE
Fix document search in PDF viewer

### DIFF
--- a/file.php
+++ b/file.php
@@ -237,6 +237,7 @@ $allowSearch   = !empty($perms['search']);
     pdfDoc = doc;
     pdfViewer.setDocument(doc);
     linkService.setDocument(doc);
+    findController.setDocument(doc);
     document.getElementById('pageCount').textContent = doc.numPages;
     document.getElementById('statusText').textContent = "Ready";
     pdfViewer.currentScaleValue = 'page-width';


### PR DESCRIPTION
## Summary
- Correct PDF search by setting the PDFFindController's document after loading

## Testing
- `php -l file.php`


------
https://chatgpt.com/codex/tasks/task_e_68b09c68a45083278bff7ce02a16c2f6