### PR TITLE
Fix PDF viewer scrolling on Windows

### DIFF
--- a/file.php
+++ b/file.php
@@ -116,8 +116,8 @@ $showSearchUi  = $allowSearch && false; // keep hidden to match requested UI
   .thumb.selected{outline:2px solid var(--ui-accent);outline-offset:2px}
   .thumb canvas{width:100%;display:block}
 
-  .viewer{position:relative;background:color-mix(in srgb, var(--ui-bg) 70%, black 10%)}
-  #viewerContainer{position:absolute;inset:0;overflow:auto}
+  .viewer{position:relative;background:color-mix(in srgb, var(--ui-bg) 70%, black 10%);height:100%}
+  #viewerContainer{height:100%;overflow:auto}
   .pdfViewer .page{margin:10px auto;background:#fff;border-radius:10px;border:1px solid #d7dae0}
 
   .search{display:flex;align-items:center;gap:8px;background:var(--ui-bar-darker);border:1px solid var(--ui-border);border-radius:20px;padding:0 10px;height:32px}


### PR DESCRIPTION
## Summary
- ensure PDF viewer container fills available height and allows overflow

## Testing
- `php -l file.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0a62b921083278bfad9f78479c985