### PR TITLE
Remove duplicate sheet declaration in file.php

### DIFF
--- a/file.php
+++ b/file.php
@@ -351,7 +351,6 @@ if (!empty($perms['analytics'])) {
 
   /* ---------- Sidebar toggle ---------- */
   const sidebar = document.getElementById('sidebar');
-  const sheet = document.getElementById('sheet');
   let open = true;
   document.getElementById('toggleSidebar').onclick = ()=>{
     open = !open;


### PR DESCRIPTION
## Summary
- Remove redundant `sheet` DOM lookup causing `Identifier 'sheet' has already been declared` runtime error.

## Testing
- `php -l file.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0be74b4508327b86f08bdb9df8b31