### PR TITLE
Hide sidebar by default

### DIFF
--- a/file.php
+++ b/file.php
@@ -351,7 +351,9 @@ if (!empty($perms['analytics'])) {
 
   /* ---------- Sidebar toggle ---------- */
   const sidebar = document.getElementById('sidebar');
-  let open = true;
+  let open = false;
+  sidebar.style.display = 'none';
+  sheet.style.gridTemplateColumns = '1fr';
   document.getElementById('toggleSidebar').onclick = ()=>{
     open = !open;
     sidebar.style.display = open ? '' : 'none';


### PR DESCRIPTION
## Summary
- Start the PDF viewer with the sidebar hidden
- Preserve toggling logic so users can open the sidebar on demand

## Testing
- `php -l file.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0c17fad708327a3875b36b57e5e62