### PR TITLE
Default mobile view to page-fit

### DIFF
--- a/file.php
+++ b/file.php
@@ -196,7 +196,8 @@ if (!empty($perms['analytics'])) {
     linkSvc.setDocument(doc, null);
     pdfHistory.initialize({ fingerprint: doc.fingerprints?.[0] || String(Date.now()) });
     pdfViewer.setDocument(doc);
-    pdfViewer.currentScaleValue = 'page-width';
+    // Use page-fit on small screens to show the whole page by default
+    pdfViewer.currentScaleValue = window.matchMedia('(max-width: 600px)').matches ? 'page-fit' : 'page-width';
     updateZoomLabel();
 
     await buildThumbnails(doc);


### PR DESCRIPTION
## Summary
- Default the PDF viewer to `page-fit` on narrow screens so mobile users see the whole page by default.

## Testing
- `php -l file.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0ce0a60c0832785b3626a87b271e8