### PR TITLE
Hide download option without permission

### DIFF
--- a/file.php
+++ b/file.php
@@ -138,9 +138,11 @@ if (!empty($perms['analytics'])) {
 
   <div class="spacer"></div>
 
+<?php if (!empty($perms['download'])): ?>
   <a class="tb" id="downloadBtn" title="Download" href="<?php echo htmlspecialchars($pdfUrl); ?>" download>
     <i class="bi bi-download"></i>
   </a>
+<?php endif; ?>
 </div>
 
 <div class="sheet" id="sheet">


### PR DESCRIPTION
## Summary
- Render download button only when link has `download` permission

## Testing
- `php -l file.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1df3b74708327bf1d9599cc833ed1