### PR TITLE
Secure file delivery based on permissions

### DIFF
--- a/file.php
+++ b/file.php
@@ -8,15 +8,17 @@ if (!$slug) {
 }
 if (!$slug) { echo 'Missing link code'; exit; }
 
-$stmt = $mysqli->prepare("SELECT l.id, l.permissions, d.filepath FROM links l JOIN documents d ON l.document_id=d.id WHERE l.slug=?");
+// Fetch link information and permissions
+$stmt = $mysqli->prepare("SELECT l.id, l.permissions FROM links l WHERE l.slug=?");
 $stmt->bind_param('s', $slug);
 $stmt->execute();
-$stmt->bind_result($linkId, $permJson, $filepath);
+$stmt->bind_result($linkId, $permJson);
 if (!$stmt->fetch()) { echo 'Invalid link'; exit; }
 $stmt->close();
 
-$basePath = rtrim(dirname($_SERVER['SCRIPT_NAME'] ?? ''), '/');
-$pdfUrl   = $basePath . '/' . ltrim($filepath, '/');
+$basePath   = rtrim(dirname($_SERVER['SCRIPT_NAME'] ?? ''), '/');
+$pdfUrl     = $basePath . '/get_pdf.php?code=' . urlencode($slug);
+$downloadUrl = $pdfUrl . '&download=1';
 
 $perms = json_decode($permJson, true) ?? [];
 if (!empty($perms['analytics'])) {
@@ -138,11 +140,11 @@ if (!empty($perms['analytics'])) {
 
   <div class="spacer"></div>
 
-<?php if (!empty($perms['download'])): ?>
-  <a class="tb" id="downloadBtn" title="Download" href="<?php echo htmlspecialchars($pdfUrl); ?>" download>
-    <i class="bi bi-download"></i>
-  </a>
-<?php endif; ?>
+  <?php if (!empty($perms['download'])): ?>
+    <a class="tb" id="downloadBtn" title="Download" href="<?php echo htmlspecialchars($downloadUrl); ?>" download>
+      <i class="bi bi-download"></i>
+    </a>
+  <?php endif; ?>
 </div>
 
 <div class="sheet" id="sheet">

--- a/get_pdf.php
+++ b/get_pdf.php
@@ -1,0 +1,49 @@
+<?php
+require_once __DIR__ . '/config.php';
+
+$slug = $_GET['code'] ?? '';
+if (!$slug) {
+    http_response_code(400);
+    echo 'Missing link code';
+    exit;
+}
+
+// Lookup the document path and permissions using the slug
+$stmt = $mysqli->prepare("SELECT l.permissions, d.filepath FROM links l JOIN documents d ON l.document_id = d.id WHERE l.slug = ?");
+$stmt->bind_param('s', $slug);
+$stmt->execute();
+$stmt->bind_result($permJson, $filepath);
+if (!$stmt->fetch()) {
+    http_response_code(404);
+    echo 'Invalid link';
+    exit;
+}
+$stmt->close();
+
+$perms = json_decode($permJson, true) ?? [];
+
+// If a download is requested, ensure the permission is granted
+$download = isset($_GET['download']);
+if ($download && empty($perms['download'])) {
+    http_response_code(403);
+    echo 'Download not permitted';
+    exit;
+}
+
+if (!is_file($filepath)) {
+    http_response_code(404);
+    echo 'File not found';
+    exit;
+}
+
+$filename = basename($filepath);
+header('Content-Type: application/pdf');
+header('Content-Length: ' . filesize($filepath));
+if ($download) {
+    header('Content-Disposition: attachment; filename="' . $filename . '"');
+} else {
+    header('Content-Disposition: inline; filename="' . $filename . '"');
+}
+
+// Stream the file contents
+readfile($filepath);

--- a/vendor_dashboard/api/list_files.php
+++ b/vendor_dashboard/api/list_files.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__ . '/../../config.php';
 
-$result = $mysqli->query("SELECT d.id, d.filename, d.size, d.filepath, l.slug FROM documents d LEFT JOIN links l ON l.document_id = d.id ORDER BY d.uploaded_at DESC");
+$result = $mysqli->query("SELECT d.id, d.filename, d.size, d.uploaded_at AS updated_at, l.slug FROM documents d LEFT JOIN links l ON l.document_id = d.id ORDER BY d.uploaded_at DESC");
 $files = [];
 $scheme   = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https://' : 'http://';
 $host     = $_SERVER['HTTP_HOST'] ?? 'localhost';
@@ -13,6 +13,8 @@ while ($row = $result->fetch_assoc()) {
         $row['url'] = $scheme . $host . $basePath . '/file/' . $row['slug'];
     }
     unset($row['slug']);
+    // The filepath is internal and should not be exposed to the client
+    unset($row['filepath']);
     $files[] = $row;
 }
 


### PR DESCRIPTION
## Summary
- Stream PDFs through new `get_pdf.php` endpoint that checks link permissions before serving or downloading
- Hide download option when links lack download permission
- Stop exposing internal file paths in file list API responses

## Testing
- `php -l get_pdf.php`
- `php -l file.php`
- `php -l vendor_dashboard/api/list_files.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1e1a55c2c8327b06869d8e1993088