### PR TITLE
Restrict direct PDF access

### DIFF
--- a/get_pdf.php
+++ b/get_pdf.php
@@ -1,6 +1,15 @@
 <?php
 require_once __DIR__ . '/config.php';
 
+// Prevent direct access by ensuring the request originates from our domain
+$referrer = $_SERVER['HTTP_REFERER'] ?? '';
+$host     = $_SERVER['HTTP_HOST'] ?? '';
+if (!$referrer || parse_url($referrer, PHP_URL_HOST) !== $host) {
+    http_response_code(403);
+    echo 'Access is denied';
+    exit;
+}
+
 $slug = $_GET['code'] ?? '';
 if (!$slug) {
     http_response_code(400);


### PR DESCRIPTION
## Summary
- Restrict get_pdf endpoint so PDF content only loads when requested from site pages, returning 403 for direct access

## Testing
- `php -l get_pdf.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1e47d76c48327beddc18901cb2625