### PR TITLE
Harden file upload and session handling security

### DIFF
--- a/config.php
+++ b/config.php
@@ -1,4 +1,15 @@
 <?php
-session_start();
+session_set_cookie_params([
+    'lifetime' => 0,
+    'path'     => '/',
+    'secure'   => isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off',
+    'httponly' => true,
+    'samesite' => 'Lax',
+]);
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
 require_once __DIR__ . '/vendor_dashboard/db.php';
 ?>

--- a/uploads/.gitignore
+++ b/uploads/.gitignore
@@ -1,2 +1,3 @@
 *
 !.gitignore
+!.htaccess

--- a/uploads/.htaccess
+++ b/uploads/.htaccess
@@ -1,0 +1,2 @@
+# Deny direct access to uploaded files
+Require all denied

--- a/vendor_dashboard/api/_login_user.php
+++ b/vendor_dashboard/api/_login_user.php
@@ -22,6 +22,7 @@ $stmt->execute();
 $result = $stmt->get_result();
 $user = $result->fetch_assoc();
 if ($user && password_verify($password, $user['password'])) {
+    session_regenerate_id(true);
     $_SESSION['user_id'] = $user['id'];
     $_SESSION['user_name'] = $user['first_name'];
     echo json_encode(['success' => true]);

--- a/vendor_dashboard/api/upload_file.php
+++ b/vendor_dashboard/api/upload_file.php
@@ -18,7 +18,7 @@ if ($file['error'] !== UPLOAD_ERR_OK) {
 
 // Validate file type (PDF or image)
 $finfo = finfo_open(FILEINFO_MIME_TYPE);
-$mime = finfo_file($finfo, $file['tmp_name']);
+$mime  = finfo_file($finfo, $file['tmp_name']);
 finfo_close($finfo);
 if (strpos($mime, 'application/pdf') !== 0 && strpos($mime, 'image/') !== 0) {
     http_response_code(400);
@@ -39,23 +39,30 @@ if (!is_dir($uploadDir)) {
     mkdir($uploadDir, 0777, true);
 }
 
-$filename = basename($file['name']);
-$target = $uploadDir . $filename;
-$index = 1;
-while (file_exists($target)) {
-    $target = $uploadDir . $index . '_' . $filename;
-    $index++;
-}
+// Sanitize original filename for display/storage
+$originalName  = $file['name'];
+$sanitizedName = preg_replace('/[^A-Za-z0-9.\-_]/', '_', $originalName);
+$extension     = strtolower(pathinfo($sanitizedName, PATHINFO_EXTENSION));
+
+// Generate random stored filename to avoid collisions and execution of user-supplied names
+do {
+    $storedName = bin2hex(random_bytes(8));
+    if ($extension) {
+        $storedName .= '.' . $extension;
+    }
+    $target = $uploadDir . $storedName;
+} while (file_exists($target));
 
 if (!move_uploaded_file($file['tmp_name'], $target)) {
     http_response_code(500);
     echo json_encode(['error' => 'Failed to save file']);
     exit;
 }
+chmod($target, 0644);
 
 $stmt = $mysqli->prepare("INSERT INTO documents (filename, filepath, size) VALUES (?,?,?)");
-$relative = 'uploads/' . basename($target);
-$stmt->bind_param('ssi', $filename, $relative, $file['size']);
+$relative = 'uploads/' . $storedName;
+$stmt->bind_param('ssi', $sanitizedName, $relative, $file['size']);
 $stmt->execute();
 
 echo json_encode(['success' => true]);


### PR DESCRIPTION
## Summary
- Enforce secure cookie settings during session start
- Regenerate session IDs after user login
- Sanitize and randomize uploaded filenames and deny direct file access

## Testing
- `php -l config.php`
- `php -l vendor_dashboard/api/_login_user.php`
- `php -l vendor_dashboard/api/upload_file.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1e7a6fafc8327a142c509ecf9c0ba