### PR TITLE
Ensure PDF links reused when updating permissions

### DIFF
--- a/vendor_dashboard/api/generate_link.php
+++ b/vendor_dashboard/api/generate_link.php
@@ -17,16 +17,40 @@ if ($perms === null) {
     $permJson = '{}';
 }
 
-// Generate unique slug
-$slug = bin2hex(random_bytes(5));
-
 // Build base URL dynamically for localhost or production
 $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https://' : 'http://';
 $host   = $_SERVER['HTTP_HOST'] ?? 'localhost';
 // Determine the application's base path (e.g. "/onepdf-view") so generated
 // links work whether the project lives in a subdirectory or at the web root.
 $basePath = rtrim(dirname(dirname(dirname($_SERVER['SCRIPT_NAME'] ?? ''))), '/');
-$url      = $scheme . $host . $basePath . '/file/' . $slug;
+
+// Check if a link already exists for this document. If so, simply update
+// its permissions and return the existing URL instead of creating a new slug.
+$stmt = $mysqli->prepare("SELECT slug FROM links WHERE document_id = ? LIMIT 1");
+$stmt->bind_param('i', $id);
+$stmt->execute();
+$stmt->bind_result($existingSlug);
+if ($stmt->fetch()) {
+    $stmt->close();
+
+    $stmt = $mysqli->prepare("UPDATE links SET permissions = ? WHERE document_id = ?");
+    $stmt->bind_param('si', $permJson, $id);
+    $stmt->execute();
+    if ($stmt->affected_rows < 0) {
+        http_response_code(500);
+        echo json_encode(['error' => 'Failed to update link']);
+        exit;
+    }
+
+    $url = $scheme . $host . $basePath . '/file/' . $existingSlug;
+    echo json_encode(['url' => $url]);
+    exit;
+}
+$stmt->close();
+
+// No existing link: generate a new slug and insert a new row.
+$slug = bin2hex(random_bytes(5));
+$url  = $scheme . $host . $basePath . '/file/' . $slug;
 
 $stmt = $mysqli->prepare("INSERT INTO links (document_id, slug, permissions) VALUES (?,?,?)");
 $stmt->bind_param('iss', $id, $slug, $permJson);


### PR DESCRIPTION
## Summary
- Avoid generating new slugs for an existing document link
- Update permissions on existing links and return the current URL

## Testing
- `php -l vendor_dashboard/api/generate_link.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1e9a2d47c832791b971895a852a51