### PR TITLE
Add embed viewer option

### DIFF
--- a/vendor_dashboard/embed.php
+++ b/vendor_dashboard/embed.php
@@ -1,0 +1,25 @@
+<?php
+$url = $_GET['url'] ?? '';
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Embed PDF Viewer</title>
+  <style>
+    body{font-family:Arial,sans-serif;margin:20px;}
+    pre{background:#f4f4f4;padding:10px;border-radius:6px;overflow:auto;}
+    iframe{width:100%;height:500px;border:1px solid #ddd;border-radius:6px;}
+  </style>
+</head>
+<body>
+  <h1>Manual integration</h1>
+  <p>Copy the code snippet below</p>
+<?php if ($url): ?>
+  <pre><code>&lt;iframe src="<?php echo htmlspecialchars($url, ENT_QUOTES); ?>" width="100%" height="500" style="border:none;"&gt;&lt;/iframe&gt;</code></pre>
+  <iframe src="<?php echo htmlspecialchars($url, ENT_QUOTES); ?>" style="border:none;"></iframe>
+<?php else: ?>
+  <p>No URL provided.</p>
+<?php endif; ?>
+</body>
+</html>

--- a/vendor_dashboard/file_list.php
+++ b/vendor_dashboard/file_list.php
@@ -221,6 +221,9 @@ include 'includes/topbar.php';
             <button class="btn btn-outline-secondary btn-sm btn-icon copy" data-url="${url}" ${url ? '' : 'disabled'}>
               <i class="bi bi-clipboard"></i> Copy
             </button>
+            <button class="btn btn-outline-info btn-sm btn-icon embed" data-url="${url}" ${url ? '' : 'disabled'}>
+              <i class="bi bi-code-slash"></i> Embed
+            </button>
             <button class="btn btn-outline-danger btn-sm delete" data-id="${f.id}">
               <i class="bi bi-trash"></i>
             </button>
@@ -298,6 +301,13 @@ include 'includes/topbar.php';
     const ta = document.createElement('textarea');
     ta.value = url; document.body.appendChild(ta); ta.select(); document.execCommand('copy'); document.body.removeChild(ta);
     showAlert('Link copied to clipboard.', 'success');
+  });
+
+  // Embed
+  $tbody.on('click', '.embed', function(){
+    const url = $(this).data('url') || '';
+    if(!url) return;
+    window.open('embed.php?url=' + encodeURIComponent(url), '_blank');
   });
 
   // Bulk select


### PR DESCRIPTION
## Summary
- add Embed action button to file list for generating CloudPDF embed view
- create embed.php page showing CloudPDF snippet and live viewer
- replace external CloudPDF viewer with custom iframe-based embed snippet

## Testing
- `php -l vendor_dashboard/embed.php`
- `php -l vendor_dashboard/file_list.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1ecb14d088327925f6353f11d4716