### PR TITLE
Use dashboard layout for embed viewer

### DIFF
--- a/vendor_dashboard/embed.php
+++ b/vendor_dashboard/embed.php
@@ -1,25 +1,33 @@
 <?php
+require_once __DIR__ . '/../config.php';
+include 'includes/header.php';
+include 'includes/sidebar.php';
+include 'includes/topbar.php';
+
 $url = $_GET['url'] ?? '';
 ?>
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <title>Embed PDF Viewer</title>
-  <style>
-    body{font-family:Arial,sans-serif;margin:20px;}
-    pre{background:#f4f4f4;padding:10px;border-radius:6px;overflow:auto;}
-    iframe{width:100%;height:500px;border:1px solid #ddd;border-radius:6px;}
-  </style>
-</head>
-<body>
-  <h1>Manual integration</h1>
-  <p>Copy the code snippet below</p>
-<?php if ($url): ?>
-  <pre><code>&lt;iframe src="<?php echo htmlspecialchars($url, ENT_QUOTES); ?>" width="100%" height="500" style="border:none;"&gt;&lt;/iframe&gt;</code></pre>
-  <iframe src="<?php echo htmlspecialchars($url, ENT_QUOTES); ?>" style="border:none;"></iframe>
-<?php else: ?>
-  <p>No URL provided.</p>
-<?php endif; ?>
-</body>
-</html>
+
+<style>
+  pre{background:#f4f4f4;padding:10px;border-radius:6px;overflow:auto;}
+  iframe{width:100%;height:500px;border:1px solid #ddd;border-radius:6px;}
+</style>
+
+<div class="container-fluid">
+  <div class="d-sm-flex align-items-center justify-content-between mb-3">
+    <h1 class="h3 mb-0 text-gray-800">Embed PDF Viewer</h1>
+  </div>
+
+  <div class="card shadow-sm">
+    <div class="card-body">
+      <?php if ($url): ?>
+        <p class="mb-3">Copy the code snippet below:</p>
+        <pre><code>&lt;iframe src="<?php echo htmlspecialchars($url, ENT_QUOTES); ?>" width="100%" height="500" style="border:none;"&gt;&lt;/iframe&gt;</code></pre>
+        <iframe src="<?php echo htmlspecialchars($url, ENT_QUOTES); ?>" style="border:none;"></iframe>
+      <?php else: ?>
+        <p>No URL provided.</p>
+      <?php endif; ?>
+    </div>
+  </div>
+</div>
+
+<?php include 'includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- Adopt vendor dashboard layout for `embed.php`
- Display embed code and preview inside a styled card

## Testing
- `php -l vendor_dashboard/embed.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1efb23c20832792b2216bcff75272