### PR TITLE
Add migration check for link analytics timestamp column

### DIFF
--- a/vendor_dashboard/db.php
+++ b/vendor_dashboard/db.php
@@ -53,4 +53,10 @@ $mysqli->query("CREATE TABLE IF NOT EXISTS link_analytics (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (link_id) REFERENCES links(id) ON DELETE CASCADE
 )");
+
+// Ensure created_at exists for installations created before this column
+$colRes = $mysqli->query("SHOW COLUMNS FROM link_analytics LIKE 'created_at'");
+if ($colRes && $colRes->num_rows === 0) {
+    $mysqli->query("ALTER TABLE link_analytics ADD COLUMN created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP");
+}
 ?>


### PR DESCRIPTION
## Summary
- Ensure `link_analytics` table includes `created_at` timestamp column, adding it automatically if missing

## Testing
- `php -l vendor_dashboard/db.php`
- `php -l vendor_dashboard/analytics.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1f8574abc83278bc15fa732ebf278