### PR TITLE
Allow extensionless PHP URLs via rewrite rules

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -6,3 +6,8 @@ RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 
 RewriteRule ^file/([a-zA-Z0-9]+)/?$ file.php?code=$1 [L,QSA]
+
+# Allow accessing PHP files without specifying the ".php" extension
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule ^([a-zA-Z0-9_-]+)/?$ $1.php [L,QSA]


### PR DESCRIPTION
## Summary
- Enable serving PHP pages without `.php` extension via mod_rewrite

## Testing
- `apache2ctl configtest` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f9c30bec8327819b62ab645fb6f6