### PR TITLE
Align landing page colors with header and footer palette

### DIFF
--- a/assets/webapp/css/index.css
+++ b/assets/webapp/css/index.css
@@ -1,8 +1,8 @@
 
     :root {
-      --brand: #2563eb; /* blue-600 */
-      --brand-light: #3b82f6; /* blue-500 */
-      --brand-dark: #1d4ed8; /* blue-700 */
+      --brand: var(--brand-start, #4f46e5); /* primary brand color */
+      --brand-light: #6366f1; /* lighter brand shade */
+      --brand-dark: var(--brand-end, #6d28d9); /* darker brand shade */
       --accent: #22d3ee; /* cyan-400 */
       --text: #0f172a; /* slate-900 */
       --text-light: #334155; /* slate-700 */
@@ -63,7 +63,7 @@
     /* Hero */
     .hero {
       background: radial-gradient(1200px 400px at 20% -10%, rgba(34, 211, 238, 0.15), transparent 60%),
-                  radial-gradient(1000px 500px at 110% 10%, rgba(37, 99, 235, 0.10), transparent 60%),
+                  radial-gradient(1000px 500px at 110% 10%, rgba(79, 70, 229, 0.10), transparent 60%),
                   linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
       padding: 6rem 0;
       position: relative;
@@ -77,13 +77,13 @@
       left: 0;
       right: 0;
       bottom: 0;
-      background: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%232563eb' fill-opacity='0.05'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+      background: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%234f46e5' fill-opacity='0.05'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
       opacity: 0.5;
     }
     
     .hero .badge {
-      background: rgba(34, 211, 238, 0.15);
-      color: #0e7490;
+      background: rgba(79, 70, 229, 0.1);
+      color: var(--brand);
       font-weight: 600;
       padding: 0.5rem 1rem;
       border-radius: 50px;
@@ -162,7 +162,7 @@
       align-items: center;
       justify-content: center;
       margin-bottom: 1.5rem;
-      background: rgba(37, 99, 235, 0.1);
+      background: rgba(79, 70, 229, 0.1);
       color: var(--brand);
       font-size: 1.5rem;
     }
@@ -299,7 +299,7 @@
       right: -50%;
       width: 100%;
       height: 200%;
-      background: url("data:image/svg+xml,%3Csvg width='100' height='100' viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M11 18c3.866 0 7-3.134 7-7s-3.134-7-7-7-7 3.134-7 7 3.134 7 7 7zm48 25c3.866 0 7-3.134 7-7s-3.134-7-7-7-7 3.134-7 7 3.134 7 7 7zm-43-7c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zm63 31c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zM34 90c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zm56-76c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zM12 86c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm28-65c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm23-11c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zm-6 60c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm29 22c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zM32 63c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zm57-13c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zm-9-21c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2zM60 91c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2zM35 41c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2zM12 60c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2z' fill='%232563eb' fill-opacity='0.05' fill-rule='evenodd'/%3E%3C/svg%3E");
+      background: url("data:image/svg+xml,%3Csvg width='100' height='100' viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M11 18c3.866 0 7-3.134 7-7s-3.134-7-7-7-7 3.134-7 7 3.134 7 7 7zm48 25c3.866 0 7-3.134 7-7s-3.134-7-7-7-7 3.134-7 7 3.134 7 7 7zm-43-7c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zm63 31c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zM34 90c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zm56-76c1.657 0 3-1.343 3-3s-1.343-3-3-3-3 1.343-3 3 1.343 3 3 3zM12 86c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm28-65c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm23-11c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zm-6 60c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm29 22c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zM32 63c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zm57-13c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zm-9-21c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2zM60 91c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2zM35 41c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2zM12 60c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2z' fill='%234f46e5' fill-opacity='0.05' fill-rule='evenodd'/%3E%3C/svg%3E");
       opacity: 0.5;
     }
 
@@ -414,6 +414,11 @@
       margin-bottom: 1rem;
     }
 
+    .step-icon {
+      background: rgba(79, 70, 229, 0.1);
+      color: var(--brand);
+    }
+
     /* Detailed workflow section */
     .detail-section {
       background: var(--lighter);
@@ -452,7 +457,7 @@
       left: 0;
       right: 0;
       bottom: 0;
-      background: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%232563eb' fill-opacity='0.03'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+      background: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%234f46e5' fill-opacity='0.03'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
       opacity: 0.5;
     }
     
@@ -525,7 +530,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      background: rgba(37, 99, 235, 0.1);
+      background: rgba(79, 70, 229, 0.1);
       color: var(--brand);
     }
 

--- a/index.php
+++ b/index.php
@@ -110,7 +110,7 @@ include 'include/header.php';
         <div class="col-md-6 col-lg-3">
           <div class="step-card">
             <div class="step-number">1</div>
-            <div class="feature-icon mx-auto mb-3" style="background:#ecfeff;color:#155e75;"><i class="bi bi-person-plus"></i></div>
+            <div class="feature-icon mx-auto mb-3 step-icon"><i class="bi bi-person-plus"></i></div>
             <h6>Create your account</h6>
             <p class="text-muted mb-0 small">Sign up and verify email. Add your brand logo & domain rules.</p>
           </div>
@@ -118,7 +118,7 @@ include 'include/header.php';
         <div class="col-md-6 col-lg-3">
           <div class="step-card">
             <div class="step-number">2</div>
-            <div class="feature-icon mx-auto mb-3" style="background:#fef9c3;color:#854d0e;"><i class="bi bi-file-earmark-arrow-up"></i></div>
+            <div class="feature-icon mx-auto mb-3 step-icon"><i class="bi bi-file-earmark-arrow-up"></i></div>
             <h6>Upload PDFs</h6>
             <p class="text-muted mb-0 small">Drag & drop. We process for search, thumbnails, and OCR (optional).</p>
           </div>
@@ -126,7 +126,7 @@ include 'include/header.php';
         <div class="col-md-6 col-lg-3">
           <div class="step-card">
             <div class="step-number">3</div>
-            <div class="feature-icon mx-auto mb-3" style="background:#dcfce7;color:#166534;"><i class="bi bi-sliders2-vertical"></i></div>
+            <div class="feature-icon mx-auto mb-3 step-icon"><i class="bi bi-sliders2-vertical"></i></div>
             <h6>Set permissions</h6>
             <p class="text-muted mb-0 small">Choose view-only, disable download/print, add watermarks & expiry.</p>
           </div>
@@ -134,7 +134,7 @@ include 'include/header.php';
         <div class="col-md-6 col-lg-3">
           <div class="step-card">
             <div class="step-number">4</div>
-            <div class="feature-icon mx-auto mb-3" style="background:#fae8ff;color:#6b21a8;"><i class="bi bi-graph-up"></i></div>
+            <div class="feature-icon mx-auto mb-3 step-icon"><i class="bi bi-graph-up"></i></div>
             <h6>Share & track</h6>
             <p class="text-muted mb-0 small">Share one link. See opens, location, device, and page engagement.</p>
           </div>


### PR DESCRIPTION
## Summary
- Refresh index page to use shared brand colors from header/footer
- Replace inline step icon styles with `step-icon` class
- Tune hero and feature icon backgrounds for consistent branding

## Testing
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b224c1d3e083279d60b5c8d68a8ed5