### PR TITLE
Improve hero heading text contrast

### DIFF
--- a/assets/webapp/css/index.css
+++ b/assets/webapp/css/index.css
@@ -1,9 +1,9 @@
 
     :root {
-      --brand: #333333;
-      --brand-light: #555555;
-      --brand-dark: #111111;
-      --accent: #777777;
+      --brand: #6366f1;
+      --brand-light: #818cf8;
+      --brand-dark: #4f46e5;
+      --accent: #4f46e5;
       --text: #f3f4f6; /* light gray for dark backgrounds */
       --text-light: #d1d5db;
       --muted: #9ca3af;


### PR DESCRIPTION
## Summary
- brighten brand color variables for better readability on dark backgrounds

## Testing
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b22a3d58b883278f81fa7a5daa8c4e