### PR TITLE
Allow only PDF uploads in vendor dashboard

### DIFF
--- a/vendor_dashboard/api/upload_file.php
+++ b/vendor_dashboard/api/upload_file.php
@@ -16,13 +16,13 @@ if ($file['error'] !== UPLOAD_ERR_OK) {
     exit;
 }
 
-// Validate file type (PDF or image)
+// Validate file type (PDF only)
 $finfo = finfo_open(FILEINFO_MIME_TYPE);
 $mime  = finfo_file($finfo, $file['tmp_name']);
 finfo_close($finfo);
-if (strpos($mime, 'application/pdf') !== 0 && strpos($mime, 'image/') !== 0) {
+if (strpos($mime, 'application/pdf') !== 0) {
     http_response_code(400);
-    echo json_encode(['error' => 'Only PDF or image files are allowed']);
+    echo json_encode(['error' => 'Only PDF files are allowed']);
     exit;
 }
 

--- a/vendor_dashboard/upload.php
+++ b/vendor_dashboard/upload.php
@@ -78,8 +78,8 @@ include 'includes/topbar.php';
       <div id="dropArea" class="upload-drop text-center">
         <div class="cloud mb-2"><i class="bi bi-cloud-upload"></i></div>
         <div class="h5 mb-1">Drag & drop your files here or <span id="browseLink" class="browse">Browse</span></div>
-        <div class="muted">50 MB max file size • PDF & images supported</div>
-        <input id="fileInput" type="file" class="d-none" multiple accept="application/pdf,image/*">
+        <div class="muted">50 MB max file size • PDF files only</div>
+        <input id="fileInput" type="file" class="d-none" multiple accept="application/pdf">
       </div>
     </div>
   </div>
@@ -151,7 +151,6 @@ include 'includes/topbar.php';
   function extIcon(filename){
     const ext = (filename.split('.').pop() || '').toLowerCase();
     if (['pdf'].includes(ext)) return '<i class="bi bi-file-earmark-pdf text-danger"></i>';
-    if (['jpg','jpeg','png','gif','webp','bmp','svg'].includes(ext)) return '<i class="bi bi-file-image text-primary"></i>';
     return '<i class="bi bi-file-earmark"></i>';
   }
   function extBadge(filename){
@@ -188,10 +187,10 @@ include 'includes/topbar.php';
 
     // Validate and filter
     const valid = files.filter(f=>{
-      const typeOk = /^application\/pdf$/.test(f.type) || /^image\//.test(f.type);
+      const typeOk = /^application\/pdf$/.test(f.type);
       const sizeOk = f.size <= MAX_SIZE;
       if(!typeOk){
-        showAlert('Only PDF or image files are allowed: '+ f.name, 'danger');
+        showAlert('Only PDF files are allowed: ' + f.name, 'danger');
       }else if(!sizeOk){
         showAlert('File too large (max 50MB): ' + f.name, 'danger');
       }


### PR DESCRIPTION
## Summary
- Restrict upload page to accept only PDF files
- Enforce PDF-only validation on server-side upload handler

## Testing
- `php -l vendor_dashboard/upload.php`
- `php -l vendor_dashboard/api/upload_file.php`


------
https://chatgpt.com/codex/tasks/task_e_68b2491106048327bdac8a1baf9aee31