### PR TITLE
Add per-user file uploads with automatic link generation

### DIFF
--- a/vendor_dashboard/api/_login_user.php
+++ b/vendor_dashboard/api/_login_user.php
@@ -25,6 +25,8 @@ if ($user && password_verify($password, $user['password'])) {
     session_regenerate_id(true);
     $_SESSION['user_id'] = $user['id'];
     $_SESSION['user_name'] = $user['first_name'];
+    // Store the user's unique folder id for uploads
+    $_SESSION['use_id'] = $user['use_id'];
     echo json_encode(['success' => true]);
 } else {
     echo json_encode(['error' => 'Invalid credentials']);

--- a/vendor_dashboard/api/delete_file.php
+++ b/vendor_dashboard/api/delete_file.php
@@ -1,15 +1,16 @@
 <?php
 require_once __DIR__ . '/../../config.php';
 
+$userId = $_SESSION['user_id'] ?? null;
 $id = $_POST['id'] ?? null;
-if (!$id) {
+if (!$userId || !$id) {
     http_response_code(400);
-    echo json_encode(['error' => 'Missing file id']);
+    echo json_encode(['error' => 'Missing parameters']);
     exit;
 }
 
-$stmt = $mysqli->prepare("SELECT filepath FROM documents WHERE id=?");
-$stmt->bind_param('i', $id);
+$stmt = $mysqli->prepare("SELECT filepath FROM documents WHERE id=? AND user_id=?");
+$stmt->bind_param('ii', $id, $userId);
 $stmt->execute();
 $stmt->bind_result($filepath);
 if (!$stmt->fetch()) {
@@ -24,8 +25,8 @@ if (file_exists($fullPath)) {
     unlink($fullPath);
 }
 
-$del = $mysqli->prepare("DELETE FROM documents WHERE id=?");
-$del->bind_param('i', $id);
+$del = $mysqli->prepare("DELETE FROM documents WHERE id=? AND user_id=?");
+$del->bind_param('ii', $id, $userId);
 $del->execute();
 
 echo json_encode(['success' => true]);

--- a/vendor_dashboard/db.php
+++ b/vendor_dashboard/db.php
@@ -29,11 +29,20 @@ $mysqli->query("CREATE TABLE IF NOT EXISTS users (
 // Table for uploaded documents
 $mysqli->query("CREATE TABLE IF NOT EXISTS documents (
     id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
     filename VARCHAR(255) NOT NULL,
     filepath VARCHAR(255) NOT NULL,
     size BIGINT NOT NULL,
-    uploaded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    uploaded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 )");
+
+// Ensure user_id column exists for older installations
+$colResDocs = $mysqli->query("SHOW COLUMNS FROM documents LIKE 'user_id'");
+if ($colResDocs && $colResDocs->num_rows === 0) {
+    $mysqli->query("ALTER TABLE documents ADD COLUMN user_id INT NOT NULL AFTER id");
+    $mysqli->query("ALTER TABLE documents ADD FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE");
+}
 
 // Table for generated links
 $mysqli->query("CREATE TABLE IF NOT EXISTS links (

--- a/vendor_dashboard/upload.php
+++ b/vendor_dashboard/upload.php
@@ -212,6 +212,7 @@ include 'includes/topbar.php';
         data: fd,
         contentType: false,
         processData: false,
+        dataType: 'json',
         xhr: function(){
           const xhr = $.ajaxSettings.xhr();
           if(xhr.upload){
@@ -225,11 +226,14 @@ include 'includes/topbar.php';
           }
           return xhr;
         },
-        success: function(){
+        success: function(res){
           ui.bar.css('width','100%');
           ui.pct.text('100%');
           ui.done.removeClass('d-none');
           setTimeout(()=> { ui.row.fadeOut(300, function(){ $(this).remove(); if(!uploadList.children().length){ uploadingBox.addClass('d-none'); } }); }, 800);
+          if(res && res.url){
+            showAlert('Link generated: ' + res.url, 'success');
+          }
           loadFiles();
         },
         error: function(xhr){
@@ -284,6 +288,10 @@ include 'includes/topbar.php';
           </td>
         `);
         row.append(actions);
+        if(url){
+          actions.find('.generate').prop('disabled', true);
+          actions.find('.link-holder').html(`<code>${url}</code>`);
+        }
         filesTableBody.append(row);
       });
     }, 'json').fail(function(){


### PR DESCRIPTION
## Summary
- Store user `use_id` in session upon login
- Save uploaded PDFs into user-specific folders and generate shareable links automatically
- Track owner for documents and restrict list, delete, and link-generation APIs to the logged-in user
- Update dashboard JS to surface generated links and disable regenerate button when link exists

## Testing
- `php -l vendor_dashboard/api/_login_user.php`
- `php -l vendor_dashboard/db.php`
- `php -l vendor_dashboard/api/upload_file.php`
- `php -l vendor_dashboard/api/list_files.php`
- `php -l vendor_dashboard/api/delete_file.php`
- `php -l vendor_dashboard/api/generate_link.php`
- `php -l vendor_dashboard/upload.php`


------
https://chatgpt.com/codex/tasks/task_e_68b24c48fc3083278b35a54c4203f807