### PR TITLE
Disable automatic link creation on upload

### DIFF
--- a/vendor_dashboard/api/upload_file.php
+++ b/vendor_dashboard/api/upload_file.php
@@ -93,16 +93,4 @@ $stmt->execute();
 $docId = $stmt->insert_id;
 $stmt->close();
 
-// Generate link immediately
-$slug = bin2hex(random_bytes(5));
-$stmt = $mysqli->prepare("INSERT INTO links (document_id, slug, permissions) VALUES (?, ?, '{}')");
-$stmt->bind_param('is', $docId, $slug);
-$stmt->execute();
-$stmt->close();
-
-$scheme   = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https://' : 'http://';
-$host     = $_SERVER['HTTP_HOST'] ?? 'localhost';
-$basePath = rtrim(dirname(dirname(dirname($_SERVER['SCRIPT_NAME'] ?? ''))), '/');
-$url      = $scheme . $host . $basePath . '/view?doc=' . urlencode($slug);
-
-echo json_encode(['success' => true, 'url' => $url]);
+echo json_encode(['success' => true, 'id' => $docId]);

--- a/vendor_dashboard/upload.php
+++ b/vendor_dashboard/upload.php
@@ -231,8 +231,8 @@ include 'includes/topbar.php';
           ui.pct.text('100%');
           ui.done.removeClass('d-none');
           setTimeout(()=> { ui.row.fadeOut(300, function(){ $(this).remove(); if(!uploadList.children().length){ uploadingBox.addClass('d-none'); } }); }, 800);
-          if(res && res.url){
-            showAlert('Link generated: ' + res.url, 'success');
+          if(res && res.success){
+            showAlert('File uploaded successfully.', 'success');
           }
           loadFiles();
         },


### PR DESCRIPTION
## Summary
- Stop upload API from creating share links for every file
- Update vendor dashboard to show a generic success message on upload

## Testing
- `php -l vendor_dashboard/api/upload_file.php`
- `php -l vendor_dashboard/upload.php`


------
https://chatgpt.com/codex/tasks/task_e_68b24e4a28748327b7cc714255d6b6ae