### PR TITLE
Add favicon to all pages

### DIFF
--- a/assets/new_index.html
+++ b/assets/new_index.html
@@ -20,7 +20,11 @@
   <meta name="twitter:image" content="https://pdfonelink.com/og-image.jpg">
 
   <!-- Favicon -->
-  <link rel="icon" href="/favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="favicon_io/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="favicon_io/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="favicon_io/favicon-16x16.png">
+  <link rel="manifest" href="favicon_io/site.webmanifest">
+  <link rel="shortcut icon" href="favicon_io/favicon.ico">
 
   <!-- Google Fonts - DM Sans -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/file.php
+++ b/file.php
@@ -39,6 +39,12 @@ if (!empty($perms['analytics'])) {
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf_viewer.min.css"/>
 
+<link rel="apple-touch-icon" sizes="180x180" href="assets/favicon_io/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="assets/favicon_io/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="assets/favicon_io/favicon-16x16.png">
+<link rel="manifest" href="assets/favicon_io/site.webmanifest">
+<link rel="shortcut icon" href="assets/favicon_io/favicon.ico">
+
 <style>
   :root{
     --ui-bg:#111315; --ui-bar:#2b3034; --ui-bar-darker:#23272b;

--- a/include/header.php
+++ b/include/header.php
@@ -13,6 +13,11 @@ $current_page = basename($_SERVER['SCRIPT_NAME']);
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&display=swap" rel="stylesheet">
+    <link rel="apple-touch-icon" sizes="180x180" href="<?= $web_base_url ?>assets/favicon_io/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="<?= $web_base_url ?>assets/favicon_io/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="<?= $web_base_url ?>assets/favicon_io/favicon-16x16.png">
+    <link rel="manifest" href="<?= $web_base_url ?>assets/favicon_io/site.webmanifest">
+    <link rel="shortcut icon" href="<?= $web_base_url ?>assets/favicon_io/favicon.ico">
     <link rel="stylesheet" href="assets/webapp/css/layout.css">
     <?php if (!empty($page_css)): ?>
     <link rel="stylesheet" href="<?= $page_css ?>">

--- a/login.php
+++ b/login.php
@@ -10,8 +10,13 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
+  <link rel="apple-touch-icon" sizes="180x180" href="assets/favicon_io/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon_io/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon_io/favicon-16x16.png">
+  <link rel="manifest" href="assets/favicon_io/site.webmanifest">
+  <link rel="shortcut icon" href="assets/favicon_io/favicon.ico">
   <link href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/css/toastr.min.css" rel="stylesheet"/>
- 
+
   <style>
     body {
       background: linear-gradient(to bottom, #4facfe, #0a58ca);

--- a/registration.php
+++ b/registration.php
@@ -10,7 +10,13 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
-    
+
+    <link rel="apple-touch-icon" sizes="180x180" href="assets/favicon_io/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon_io/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon_io/favicon-16x16.png">
+    <link rel="manifest" href="assets/favicon_io/site.webmanifest">
+    <link rel="shortcut icon" href="assets/favicon_io/favicon.ico">
+
     <link href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/css/toastr.min.css" rel="stylesheet"/>
     
     <style>

--- a/vendor_dashboard/includes/header.php
+++ b/vendor_dashboard/includes/header.php
@@ -17,6 +17,11 @@ $assets_path = $base_url . 'assets/';
     <link href="https://fonts.googleapis.com/css?family=Nunito:200,200i,300,300i,400,400i,600,600i,700,700i,800,800i,900,900i" rel="stylesheet">
     <!-- Bootstrap Icons CDN -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+    <link rel="apple-touch-icon" sizes="180x180" href="../assets/favicon_io/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="../assets/favicon_io/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="../assets/favicon_io/favicon-16x16.png">
+    <link rel="manifest" href="../assets/favicon_io/site.webmanifest">
+    <link rel="shortcut icon" href="../assets/favicon_io/favicon.ico">
     <!-- Custom styles for this template-->
     <link href="<?php echo $assets_path; ?>css/sb-admin-2.min.css" rel="stylesheet">
     <link href="<?php echo $assets_path; ?>css/custom.css" rel="stylesheet">

--- a/view.php
+++ b/view.php
@@ -35,6 +35,12 @@ if (!empty($perms['analytics'])) {
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf_viewer.min.css"/>
 
+<link rel="apple-touch-icon" sizes="180x180" href="assets/favicon_io/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="assets/favicon_io/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="assets/favicon_io/favicon-16x16.png">
+<link rel="manifest" href="assets/favicon_io/site.webmanifest">
+<link rel="shortcut icon" href="assets/favicon_io/favicon.ico">
+
 <style>
   :root{
     --ui-bg:#111315; --ui-bar:#2b3034; --ui-bar-darker:#23272b;


### PR DESCRIPTION
## Summary
- load favicon assets in shared site header
- include same icons in dashboard header and standalone pages

## Testing
- `php -l include/header.php`
- `php -l vendor_dashboard/includes/header.php`
- `php -l login.php`
- `php -l registration.php`
- `php -l file.php`
- `php -l view.php`


------
https://chatgpt.com/codex/tasks/task_e_68b259bd5a84832794f6a2dc4dfd397c