### PR TITLE
Add newsletter subscription with validation

### DIFF
--- a/assets/webapp/js/main.js
+++ b/assets/webapp/js/main.js
@@ -2,3 +2,51 @@ const yearEl = document.getElementById('y');
 if (yearEl) {
   yearEl.textContent = new Date().getFullYear();
 }
+
+const newsletterForm = document.getElementById('newsletterForm');
+if (newsletterForm) {
+  newsletterForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const emailInput = newsletterForm.querySelector('input[name="email"]');
+    const feedback = document.getElementById('newsletterFeedback');
+    const email = emailInput.value.trim();
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      if (feedback) {
+        feedback.textContent = 'Please enter a valid email address.';
+        feedback.classList.remove('text-success');
+        feedback.classList.add('text-danger');
+      }
+      return;
+    }
+
+    try {
+      const res = await fetch(newsletterForm.action, {
+        method: 'POST',
+        body: new FormData(newsletterForm)
+      });
+      const data = await res.json();
+      if (data.success) {
+        if (feedback) {
+          feedback.textContent = 'Subscribed successfully!';
+          feedback.classList.remove('text-danger');
+          feedback.classList.add('text-success');
+        }
+        emailInput.value = '';
+      } else {
+        if (feedback) {
+          feedback.textContent = data.error || 'Subscription failed.';
+          feedback.classList.remove('text-success');
+          feedback.classList.add('text-danger');
+        }
+      }
+    } catch (err) {
+      if (feedback) {
+        feedback.textContent = 'Subscription failed.';
+        feedback.classList.remove('text-success');
+        feedback.classList.add('text-danger');
+      }
+    }
+  });
+}

--- a/include/footer.php
+++ b/include/footer.php
@@ -42,10 +42,11 @@
         <div class="col-lg-3">
           <h6 class="mb-4">Newsletter</h6>
           <p class="small mb-3">Get the latest updates, tips, and guides.</p>
-          <form class="d-flex gap-2 mb-2" action="/subscribe" method="post">
+          <form id="newsletterForm" class="d-flex gap-2 mb-2" action="/subscribe" method="post" novalidate>
             <input type="email" class="form-control form-control-sm" name="email" placeholder="Email address" required>
             <button class="btn btn-brand btn-sm" type="submit"><i class="bi bi-arrow-right"></i></button>
           </form>
+          <div id="newsletterFeedback" class="small mb-2"></div>
           <div class="small text-secondary">No spam. Unsubscribe anytime.</div>
         </div>
       </div>

--- a/subscribe.php
+++ b/subscribe.php
@@ -1,0 +1,33 @@
+<?php
+require_once 'config.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    header('Content-Type: application/json');
+
+    $email = trim($_POST['email'] ?? '');
+
+    if (filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        $stmt = $mysqli->prepare('INSERT INTO newsletter_subscribers (email) VALUES (?)');
+        if ($stmt) {
+            $stmt->bind_param('s', $email);
+            if ($stmt->execute()) {
+                echo json_encode(['success' => true]);
+            } else {
+                http_response_code(500);
+                echo json_encode(['success' => false, 'error' => 'Failed to subscribe']);
+            }
+            $stmt->close();
+        } else {
+            http_response_code(500);
+            echo json_encode(['success' => false, 'error' => 'Database error']);
+        }
+    } else {
+        http_response_code(400);
+        echo json_encode(['success' => false, 'error' => 'Invalid email']);
+    }
+    exit;
+}
+
+header('Location: /');
+exit;
+

--- a/vendor_dashboard/db.php
+++ b/vendor_dashboard/db.php
@@ -80,4 +80,11 @@ $mysqli->query("CREATE TABLE IF NOT EXISTS contact_messages (
     message TEXT NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 )");
+
+// Table for newsletter subscriptions
+$mysqli->query("CREATE TABLE IF NOT EXISTS newsletter_subscribers (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    email VARCHAR(150) NOT NULL UNIQUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+)");
 ?>


### PR DESCRIPTION
## Summary
- add newsletter subscription form feedback and JS handler
- store newsletter emails in new `newsletter_subscribers` table
- create backend endpoint for newsletter sign-up

## Testing
- `php -l include/footer.php`
- `php -l vendor_dashboard/db.php`
- `php -l subscribe.php`
- `node --check assets/webapp/js/main.js && echo "JS syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68b25d2e7fd88327ab4b75cce1511b93