### PR TITLE
Add client-side validation to contact form

### DIFF
--- a/assets/webapp/css/contact.css
+++ b/assets/webapp/css/contact.css
@@ -161,6 +161,17 @@
             margin-bottom: 0.5rem;
             color: var(--text);
         }
+
+        .error-message {
+            color: #dc3545;
+            font-size: 0.875em;
+            margin-top: 0.25rem;
+            display: none;
+        }
+
+        .is-invalid + .error-message {
+            display: block;
+        }
         
         .faq-section {
             background: var(--lighter);

--- a/assets/webapp/js/contact.js
+++ b/assets/webapp/js/contact.js
@@ -1,40 +1,61 @@
-        // Form submission handling
-        document.getElementById('contactForm').addEventListener('submit', function(e) {
-            e.preventDefault();
+// Enhanced form validation and submission for the contact page
+document.getElementById('contactForm').addEventListener('submit', async function (e) {
+    e.preventDefault();
+    const form = e.target;
+    let valid = true;
 
-            // Simple form validation
-            const firstName = document.getElementById('firstName').value.trim();
-            const lastName  = document.getElementById('lastName').value.trim();
-            const email     = document.getElementById('email').value.trim();
-            const subject   = document.getElementById('subject').value;
-            const message   = document.getElementById('message').value.trim();
+    // Clear previous errors
+    document.querySelectorAll('#contactForm .error-message').forEach(el => el.textContent = '');
+    document.querySelectorAll('#contactForm .form-control, #contactForm .form-select, #contactForm textarea').forEach(el => el.classList.remove('is-invalid'));
 
-            if (!firstName || !lastName || !email || !subject || !message) {
-                alert('Please fill in all required fields.');
-                return;
-            }
+    const data = new FormData(form);
 
-            // Email validation
-            const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-            if (!emailRegex.test(email)) {
-                alert('Please enter a valid email address.');
-                return;
-            }
+    if (!data.get('firstName')) {
+        document.getElementById('firstName_error').textContent = 'First name is required.';
+        document.getElementById('firstName').classList.add('is-invalid');
+        valid = false;
+    }
+    if (!data.get('lastName')) {
+        document.getElementById('lastName_error').textContent = 'Last name is required.';
+        document.getElementById('lastName').classList.add('is-invalid');
+        valid = false;
+    }
+    const email = data.get('email');
+    if (!email || !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) {
+        document.getElementById('email_error').textContent = 'A valid email is required.';
+        document.getElementById('email').classList.add('is-invalid');
+        valid = false;
+    }
+    if (!data.get('subject')) {
+        document.getElementById('subject_error').textContent = 'Subject is required.';
+        document.getElementById('subject').classList.add('is-invalid');
+        valid = false;
+    }
+    if (!data.get('message')) {
+        document.getElementById('message_error').textContent = 'Message is required.';
+        document.getElementById('message').classList.add('is-invalid');
+        valid = false;
+    }
 
-            const form = this;
-            fetch('contact.php', {
-                method: 'POST',
-                body: new FormData(form)
-            })
-            .then(response => response.json())
-            .then(data => {
-                if (data.success) {
-                    alert('Thank you for your message! We will get back to you soon.');
-                    form.reset();
-                } else {
-                    alert(data.error || 'There was a problem sending your message.');
-                }
-            })
-            .catch(() => alert('There was a problem sending your message.'));
+    if (!valid) {
+        alert('Please correct the errors above.');
+        return;
+    }
+
+    try {
+        const res = await fetch('contact.php', {
+            method: 'POST',
+            body: data
         });
+        const result = await res.json();
+        if (result.success) {
+            alert('Thank you for your message! We will get back to you soon.');
+            form.reset();
+        } else {
+            alert(result.error || 'There was a problem sending your message.');
+        }
+    } catch (err) {
+        alert('There was a problem sending your message.');
+    }
+});
 

--- a/contact.php
+++ b/contact.php
@@ -67,18 +67,21 @@ include 'include/header.php';
                                     <div class="mb-3">
                                         <label for="firstName" class="form-label">First Name</label>
                                         <input type="text" class="form-control" id="firstName" name="firstName" required>
+                                        <div id="firstName_error" class="error-message"></div>
                                     </div>
                                 </div>
                                 <div class="col-md-6">
                                     <div class="mb-3">
                                         <label for="lastName" class="form-label">Last Name</label>
                                         <input type="text" class="form-control" id="lastName" name="lastName" required>
+                                        <div id="lastName_error" class="error-message"></div>
                                     </div>
                                 </div>
                             </div>
                             <div class="mb-3">
                                 <label for="email" class="form-label">Email Address</label>
                                 <input type="email" class="form-control" id="email" name="email" required>
+                                <div id="email_error" class="error-message"></div>
                             </div>
                             <div class="mb-3">
                                 <label for="company" class="form-label">Company (Optional)</label>
@@ -94,10 +97,12 @@ include 'include/header.php';
                                     <option value="partnership">Partnership Opportunity</option>
                                     <option value="other">Other</option>
                                 </select>
+                                <div id="subject_error" class="error-message"></div>
                             </div>
                             <div class="mb-4">
                                 <label for="message" class="form-label">Message</label>
                                 <textarea class="form-control" id="message" name="message" rows="5" required></textarea>
+                                <div id="message_error" class="error-message"></div>
                             </div>
                             <button type="submit" class="btn btn-brand btn-lg w-100">Send Message</button>
                         </form>


### PR DESCRIPTION
## Summary
- add inline error message containers to the contact form
- style and display validation errors
- implement JS validation and submission logic

## Testing
- `php -l contact.php`
- `node --check assets/webapp/js/contact.js && echo 'JS syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_68b26196128883278cf3eb20d678c097