### PR TITLE
Add plan selection to registration

### DIFF
--- a/registration.php
+++ b/registration.php
@@ -131,6 +131,19 @@
 
 
                 <div class="form-floating mb-3">
+                    <select name="plan_id" class="form-select" id="plan" required>
+                        <option value="" selected>Select Plan</option>
+                        <option value="1">Free - $0</option>
+                        <option value="2">Pro - $12/month</option>
+                        <option value="3">Pro - $499/year</option>
+                        <option value="4">Business - $25/month</option>
+                        <option value="5">Business - $1999/year</option>
+                    </select>
+                    <label for="plan">Plan</label>
+                </div>
+                <div id="plan_id_error" class="error-message"></div>
+
+                <div class="form-floating mb-3">
                     <input type="email" name="email" class="form-control" id="email" placeholder="name@example.com" required>
                     <label for="email">Email address</label>
                 </div>
@@ -179,7 +192,7 @@ document.getElementById('registerForm').addEventListener('submit', async functio
     
     // Clear previous errors
     document.querySelectorAll('.error-message').forEach(el => el.textContent = '');
-    document.querySelectorAll('.form-control, .form-check-input').forEach(el => el.classList.remove('is-invalid'));
+    document.querySelectorAll('.form-control, .form-select, .form-check-input').forEach(el => el.classList.remove('is-invalid'));
     
     const data = new FormData(form);
     
@@ -202,6 +215,11 @@ document.getElementById('registerForm').addEventListener('submit', async functio
     if (!data.get('company')) {
         document.getElementById('company_error').textContent = 'Company is required.';
         document.getElementById('company').classList.add('is-invalid');
+        valid = false;
+    }
+    if (!data.get('plan_id')) {
+        document.getElementById('plan_id_error').textContent = 'Plan is required.';
+        document.getElementById('plan').classList.add('is-invalid');
         valid = false;
     }
     const email = data.get('email');

--- a/vendor_dashboard/api/_save_user.php
+++ b/vendor_dashboard/api/_save_user.php
@@ -4,7 +4,7 @@ header('Content-Type: application/json');
 
 $input = $_POST;
 $errors = [];
-$required = ['country','first_name','last_name','company','email','password'];
+$required = ['country','first_name','last_name','company','plan_id','email','password'];
 foreach ($required as $field) {
     if (empty($input[$field])) {
         $errors[] = "$field is required";
@@ -18,6 +18,11 @@ if (!empty($input['password']) && strlen($input['password']) < 6) {
 }
 if (empty($input['agreed_terms'])) {
     $errors[] = 'Terms must be accepted';
+}
+
+$allowedPlans = ['1','2','3','4','5'];
+if (!empty($input['plan_id']) && !in_array($input['plan_id'], $allowedPlans)) {
+    $errors[] = 'Invalid plan selected';
 }
 
 if ($errors) {
@@ -43,6 +48,18 @@ $stmt->bind_param(
     $agreed_terms
 );
 if ($stmt->execute()) {
+    $user_id = $stmt->insert_id;
+    $plan_id = (int)$input['plan_id'];
+    $start_date = date('Y-m-d');
+    $end_date = null;
+    if (in_array($plan_id, [2,4])) {
+        $end_date = date('Y-m-d', strtotime('+1 month'));
+    } elseif (in_array($plan_id, [3,5])) {
+        $end_date = date('Y-m-d', strtotime('+1 year'));
+    }
+    $stmtPlan = $mysqli->prepare('INSERT INTO user_plan (user_id, plan_id, start_date, end_date) VALUES (?,?,?,?)');
+    $stmtPlan->bind_param('iiss', $user_id, $plan_id, $start_date, $end_date);
+    $stmtPlan->execute();
     echo json_encode(['success' => true]);
 } else {
     echo json_encode(['error' => 'Email already exists']);

--- a/vendor_dashboard/db.php
+++ b/vendor_dashboard/db.php
@@ -26,6 +26,15 @@ $mysqli->query("CREATE TABLE IF NOT EXISTS users (
     agreed_terms TINYINT(1) NOT NULL DEFAULT 0
 )");
 
+$mysqli->query("CREATE TABLE IF NOT EXISTS user_plan (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    plan_id INT NOT NULL,
+    start_date DATE NOT NULL,
+    end_date DATE DEFAULT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+)");
+
 // Table for uploaded documents
 $mysqli->query("CREATE TABLE IF NOT EXISTS documents (
     id INT AUTO_INCREMENT PRIMARY KEY,


### PR DESCRIPTION
## Summary
- add plan dropdown to registration form and client-side validation
- require plan selection server-side and store selection with start/end dates
- create `user_plan` table during database setup

## Testing
- `php -l registration.php`
- `php -l vendor_dashboard/api/_save_user.php`
- `php -l vendor_dashboard/db.php`


------
https://chatgpt.com/codex/tasks/task_e_68b2654f109483278a87cb360da24429