### PR TITLE
Add privacy and terms pages with footer links

### DIFF
--- a/include/footer.php
+++ b/include/footer.php
@@ -43,9 +43,9 @@
       <div class="footer-bottom">
         <p class="copyright">© <span id="y"></span> PDFOneLink. All rights reserved.</p>
         <div class="legal-links">
-          <a href="/privacy">Privacy Policy</a>
+          <a href="/privacy.php">Privacy Policy</a>
           <span class="divider">•</span>
-          <a href="/terms">Terms of Service</a>
+          <a href="/terms.php">Terms of Service</a>
           <span class="divider">•</span>
           <a href="/cookies">Cookie Policy</a>
         </div>

--- a/privacy.php
+++ b/privacy.php
@@ -1,0 +1,16 @@
+<?php
+$page_title = 'Privacy Policy - PDFOneLink';
+include 'include/header.php';
+?>
+
+<section class="section">
+  <div class="container">
+    <h1 class="section-title centered">Privacy Policy</h1>
+    <p class="section-subtitle">Your privacy is important to us.</p>
+    <p>This Privacy Policy explains how PDFOneLink collects, uses, and protects your information when you use our services.</p>
+    <p>By using PDFOneLink, you agree to the practices described here. We only collect information necessary to deliver and improve our services, and we never sell your data.</p>
+    <p>If you have any questions about this policy, please <a href="/contact">contact us</a>.</p>
+  </div>
+</section>
+
+<?php include 'include/footer.php'; ?>

--- a/terms.php
+++ b/terms.php
@@ -1,0 +1,16 @@
+<?php
+$page_title = 'Terms of Service - PDFOneLink';
+include 'include/header.php';
+?>
+
+<section class="section">
+  <div class="container">
+    <h1 class="section-title centered">Terms of Service</h1>
+    <p class="section-subtitle">Please read these terms carefully.</p>
+    <p>By accessing or using PDFOneLink, you agree to the following terms and conditions governing your use of our website and services.</p>
+    <p>We may update these terms from time to time. Continued use of the service constitutes acceptance of the revised terms.</p>
+    <p>If you do not agree with these terms, please discontinue using PDFOneLink.</p>
+  </div>
+</section>
+
+<?php include 'include/footer.php'; ?>


### PR DESCRIPTION
## Summary
- add simple privacy policy page
- add terms of service page
- update footer links to point to new policy pages

## Testing
- `php -l privacy.php`
- `php -l terms.php`
- `php -l include/footer.php`


------
https://chatgpt.com/codex/tasks/task_e_68b269bdf7c08327a5f9243901fdd38d