### PR TITLE
Add vendor notifications dropdown and page

### DIFF
--- a/vendor_dashboard/db.php
+++ b/vendor_dashboard/db.php
@@ -116,4 +116,24 @@ $mysqli->query("CREATE TABLE IF NOT EXISTS newsletter_subscribers (
     email VARCHAR(150) NOT NULL UNIQUE,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 )");
+
+// Table for notifications
+$mysqli->query("CREATE TABLE IF NOT EXISTS notifications (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    user_id INT UNSIGNED NULL,
+    audience ENUM('user','all') NOT NULL DEFAULT 'user',
+    title VARCHAR(255) NOT NULL,
+    message TEXT NOT NULL,
+    type ENUM('info','success','warning','error','system') DEFAULT 'info',
+    priority TINYINT UNSIGNED NOT NULL DEFAULT 1,
+    action_url VARCHAR(1024) DEFAULT NULL,
+    is_read TINYINT(1) NOT NULL DEFAULT 0,
+    read_at DATETIME DEFAULT NULL,
+    metadata JSON DEFAULT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    KEY idx_user_unread_created (audience, user_id, is_read, created_at),
+    KEY idx_created (created_at),
+    CONSTRAINT fk_notifications_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");
 ?>

--- a/vendor_dashboard/notifications.php
+++ b/vendor_dashboard/notifications.php
@@ -1,0 +1,46 @@
+<?php
+require_once __DIR__ . '/../config.php';
+if (!isset($_SESSION['user_id'])) {
+    header('Location: ../login');
+    exit;
+}
+$userId = $_SESSION['user_id'];
+
+// Mark notifications as read
+$stmt = $mysqli->prepare("UPDATE notifications SET is_read=1, read_at=NOW() WHERE (audience='all' OR (audience='user' AND user_id=?)) AND is_read=0");
+$stmt->bind_param('i', $userId);
+$stmt->execute();
+$stmt->close();
+
+// Fetch notifications
+$stmt = $mysqli->prepare("SELECT title, message, type, created_at FROM notifications WHERE (audience='all' OR (audience='user' AND user_id=?)) ORDER BY created_at DESC");
+$stmt->bind_param('i', $userId);
+$stmt->execute();
+$notifications = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+$stmt->close();
+
+include 'includes/header.php';
+include 'includes/sidebar.php';
+include 'includes/topbar.php';
+?>
+<div class="container-fluid">
+    <h1 class="h3 mb-4 text-gray-800">Notifications</h1>
+    <?php if (empty($notifications)): ?>
+        <p>No notifications found.</p>
+    <?php else: ?>
+        <div class="card shadow mb-4">
+            <div class="card-body">
+                <ul class="list-group list-group-flush">
+                    <?php foreach ($notifications as $note): ?>
+                    <li class="list-group-item">
+                        <div class="small text-gray-500"><?php echo date('F j, Y', strtotime($note['created_at'])); ?></div>
+                        <strong><?php echo htmlspecialchars($note['title']); ?></strong>
+                        <div><?php echo htmlspecialchars($note['message']); ?></div>
+                    </li>
+                    <?php endforeach; ?>
+                </ul>
+            </div>
+        </div>
+    <?php endif; ?>
+</div>
+<?php include 'includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- Add notifications table creation and dynamic dropdown
- Provide dedicated notifications page and mark-as-read logic

## Testing
- `php -l vendor_dashboard/includes/topbar.php`
- `php -l vendor_dashboard/db.php`
- `php -l vendor_dashboard/notifications.php`


------
https://chatgpt.com/codex/tasks/task_e_68b273093fe8832781e840837c0b45b1