### PR TITLE
Fix notifications user foreign key

### DIFF
--- a/vendor_dashboard/db.php
+++ b/vendor_dashboard/db.php
@@ -120,7 +120,7 @@ $mysqli->query("CREATE TABLE IF NOT EXISTS newsletter_subscribers (
 // Table for notifications
 $mysqli->query("CREATE TABLE IF NOT EXISTS notifications (
     id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    user_id INT UNSIGNED NULL,
+    user_id INT NULL,
     audience ENUM('user','all') NOT NULL DEFAULT 'user',
     title VARCHAR(255) NOT NULL,
     message TEXT NOT NULL,


### PR DESCRIPTION
## Summary
- ensure notifications user_id uses signed INT to align with users.id foreign key

## Testing
- `php -l vendor_dashboard/db.php`


------
https://chatgpt.com/codex/tasks/task_e_68b2746e92a88327b909105cd0064a80