### PR TITLE
Add plan upgrade modal for vendor dashboard

### DIFF
--- a/vendor_dashboard/api/_update_plan.php
+++ b/vendor_dashboard/api/_update_plan.php
@@ -1,0 +1,57 @@
+<?php
+require_once __DIR__ . '/../../config.php';
+header('Content-Type: application/json');
+
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    echo json_encode(['error' => 'Unauthorized']);
+    exit;
+}
+
+$user_id = $_SESSION['user_id'];
+$plan_id = intval($_POST['plan_id'] ?? 0);
+
+if (!$plan_id) {
+    echo json_encode(['error' => 'Invalid plan']);
+    exit;
+}
+
+// Fetch plan info
+$stmt = $mysqli->prepare('SELECT billing_cycle FROM plans WHERE id = ?');
+$stmt->bind_param('i', $plan_id);
+$stmt->execute();
+$plan = $stmt->get_result()->fetch_assoc();
+if (!$plan) {
+    echo json_encode(['error' => 'Plan not found']);
+    exit;
+}
+
+$billing = $plan['billing_cycle'];
+$start_date = date('Y-m-d');
+$end_date = null;
+if ($billing === 'month') {
+    $end_date = date('Y-m-d', strtotime('+1 month'));
+} elseif ($billing === 'year') {
+    $end_date = date('Y-m-d', strtotime('+1 year'));
+}
+
+$mysqli->begin_transaction();
+try {
+    // Mark existing plans inactive
+    $stmt = $mysqli->prepare('UPDATE user_plan SET status = 2 WHERE user_id = ? AND status = 1');
+    $stmt->bind_param('i', $user_id);
+    $stmt->execute();
+
+    // Insert new plan
+    $stmt = $mysqli->prepare('INSERT INTO user_plan (user_id, plan_id, start_date, end_date, status) VALUES (?, ?, ?, ?, 1)');
+    $stmt->bind_param('iiss', $user_id, $plan_id, $start_date, $end_date);
+    $stmt->execute();
+
+    $mysqli->commit();
+    echo json_encode(['success' => true]);
+} catch (Exception $e) {
+    $mysqli->rollback();
+    http_response_code(500);
+    echo json_encode(['error' => 'Failed to update plan']);
+}
+?>

--- a/vendor_dashboard/plan.php
+++ b/vendor_dashboard/plan.php
@@ -4,11 +4,23 @@ if (!isset($_SESSION['user_id'])) {
     header('Location: ../login');
     exit;
 }
+
 $user_id = $_SESSION['user_id'];
-$stmt = $mysqli->prepare('SELECT p.name, p.price, p.billing_cycle, up.start_date, up.end_date FROM user_plan up JOIN plans p ON up.plan_id = p.id WHERE up.user_id = ? ORDER BY up.start_date DESC LIMIT 1');
+
+// Get current active plan for the user
+$stmt = $mysqli->prepare('SELECT p.id as plan_id, p.name, p.price, p.billing_cycle, up.start_date, up.end_date FROM user_plan up JOIN plans p ON up.plan_id = p.id WHERE up.user_id = ? AND up.status = 1 ORDER BY up.start_date DESC LIMIT 1');
 $stmt->bind_param('i', $user_id);
 $stmt->execute();
 $plan = $stmt->get_result()->fetch_assoc();
+
+// Fetch available plans (exclude current plan if exists)
+$plans_res = $mysqli->query('SELECT id, name, price, billing_cycle FROM plans ORDER BY price');
+$available_plans = [];
+while ($row = $plans_res->fetch_assoc()) {
+    if (!$plan || $row['id'] != $plan['plan_id']) {
+        $available_plans[] = $row;
+    }
+}
 include 'includes/header.php';
 include 'includes/sidebar.php';
 include 'includes/topbar.php';
@@ -28,8 +40,68 @@ include 'includes/topbar.php';
             <?php else: ?>
                 <p>You are currently on the <strong>Free</strong> plan.</p>
             <?php endif; ?>
-            <a href="../pricing" class="btn btn-primary mt-3"><i class="bi bi-arrow-up-circle mr-1"></i> Upgrade Plan</a>
+            <button class="btn btn-primary mt-3" data-toggle="modal" data-target="#upgradeModal"><i class="bi bi-arrow-up-circle mr-1"></i> Upgrade Plan</button>
         </div>
     </div>
 </div>
+
+<!-- Upgrade Plan Modal -->
+<div class="modal fade" id="upgradeModal" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Select Plan</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <form id="planForm">
+                <div class="modal-body">
+                    <div class="form-group">
+                        <label for="planSelect">Available Plans</label>
+                        <select class="form-control" id="planSelect" name="plan_id" required>
+                            <option value="">Select a plan</option>
+                            <?php foreach ($available_plans as $p): ?>
+                                <option value="<?php echo htmlspecialchars($p['id']); ?>">
+                                    <?php echo htmlspecialchars($p['name'] . ' - $' . $p['price'] . ' / ' . $p['billing_cycle']); ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                    <button type="submit" id="btnPlanSave" class="btn btn-primary">Save</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<script>
+$(function(){
+    $('#planForm').on('submit', function(e){
+        e.preventDefault();
+        var btn = $('#btnPlanSave');
+        btn.prop('disabled', true).html('<span class="spinner-border spinner-border-sm mr-1" role="status" aria-hidden="true"></span>Saving...');
+        $.ajax({
+            url: 'api/_update_plan.php',
+            method: 'POST',
+            data: $(this).serialize(),
+            dataType: 'json'
+        }).done(function(res){
+            if (res.success) {
+                location.reload();
+            } else {
+                alert(res.error || 'Update failed');
+            }
+        }).fail(function(){
+            alert('Network error. Please try again.');
+        }).always(function(){
+            btn.prop('disabled', false).html('Save');
+        });
+    });
+});
+</script>
+
 <?php include 'includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- Show available plans in a modal for vendor plan upgrades
- Persist selected plan via new API endpoint

## Testing
- `php -l vendor_dashboard/plan.php`
- `php -l vendor_dashboard/api/_update_plan.php`


------
https://chatgpt.com/codex/tasks/task_e_68b27c5ab1ac832780b77d3018d65812